### PR TITLE
Fixes #21 and #22 - deadlock and crash at exit

### DIFF
--- a/examples/vmcall_interface.cc
+++ b/examples/vmcall_interface.cc
@@ -571,8 +571,8 @@ int main(int argc, char** argv) {
  * cleanly detach and exit.
  */
 void sig_handler(int signum) {
-    event_handler.cleanup();
     domain->interrupt();
+    event_handler.cleanup();
 }
 
 /**

--- a/src/core/domain/DomainImpl.hh
+++ b/src/core/domain/DomainImpl.hh
@@ -171,6 +171,13 @@ class DomainImpl : public Domain {
      */
     void initialize();
 
+    /**
+     * @brief Release the Guest before destroying vCPUs (for shutdown order).
+     * Subclass destructors should call this before clearing vcpus_ so that
+     * Guest/PDB teardown runs while the domain and vCPUs are still valid.
+     */
+    void reset_guest() { guest_.reset(); }
+
   private:
     void handle_breakpoint(Event& event);
 

--- a/src/hypervisor/kvm/KvmDomain.cc
+++ b/src/hypervisor/kvm/KvmDomain.cc
@@ -163,6 +163,12 @@ KvmDomain::KvmDomain(const KvmHypervisor& hypervisor, const std::string& name, u
 }
 
 KvmDomain::~KvmDomain() {
+    // Destroy the Guest first while vCPUs and domain are
+    // still valid. Destroying vCPUs first can lead to heap
+    // corruption since the domain is still around but the vCPUs
+    // are gone.
+    reset_guest();
+
     // Release the VCPUs before closing the domain
     vcpus_.clear();
 


### PR DESCRIPTION
closes #21 
closes #22 

Fix destructor order and cleanup steps to prevent tool deadlock/crash at exit.