### PR TITLE
Native Linux guest introspection + Win11 NtCreateUserProcess process launch

### DIFF
--- a/include/introvirt/linux/LinuxGuest.hh
+++ b/include/introvirt/linux/LinuxGuest.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/core/domain/Guest.hh>
+#include <introvirt/fwd.hh>
+
+namespace introvirt {
+namespace linux_guest {
+
+class LinuxKernel;
+
+/**
+ * @brief A representation of a Linux Guest OS.
+ *
+ * Mirrors ``windows::WindowsGuest``: the OS-specific face of the generic
+ * ``Guest`` interface. The concrete ``LinuxGuestImpl`` (added in a later
+ * increment) also implements ``GuestImpl`` and is constructed from
+ * ``DomainImpl::detect_guest()`` once a Linux kernel is detected.
+ *
+ * Unlike Windows there is no syscall *converter* here yet — the Linux
+ * syscall table + handler classes (Phase 3 in docs/introvirt-linux-port.md)
+ * are generated separately and wired in when ``ivsyscallmon`` support lands.
+ */
+class LinuxGuest : public Guest {
+  public:
+    /**
+     * @brief Get the Linux kernel parser.
+     */
+    virtual LinuxKernel& kernel() = 0;
+
+    /**
+     * @copydoc LinuxGuest::kernel()
+     */
+    virtual const LinuxKernel& kernel() const = 0;
+
+    /**
+     * @brief Get the Domain instance the guest is running on.
+     */
+    virtual Domain& domain() = 0;
+
+    /**
+     * @copydoc LinuxGuest::domain()
+     */
+    virtual const Domain& domain() const = 0;
+
+    virtual ~LinuxGuest() = default;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/event/LinuxEvent.hh
+++ b/include/introvirt/linux/event/LinuxEvent.hh
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/core/event/Event.hh>
+#include <introvirt/linux/event/LinuxEventTaskInformation.hh>
+#include <introvirt/linux/fwd.hh>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief A Linux-specific hypervisor event (mirrors windows::WindowsEvent).
+ *
+ * Narrows Event::task() to LinuxEventTaskInformation (covariant return) and
+ * exposes the owning LinuxGuest. There is no covariant syscall() yet — the
+ * Linux syscall view (LinuxSystemCallEvent + the generated table) is Phase 3.
+ */
+class LinuxEvent : public Event {
+  public:
+    virtual LinuxEventTaskInformation& task() = 0;
+    virtual const LinuxEventTaskInformation& task() const = 0;
+
+    virtual LinuxGuest& guest() = 0;
+    virtual const LinuxGuest& guest() const = 0;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/event/LinuxEventTaskInformation.hh
+++ b/include/introvirt/linux/event/LinuxEventTaskInformation.hh
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/core/event/EventTaskInformation.hh>
+
+#include <cstdint>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief Linux task information for an event (the Linux analogue of
+ * windows::WindowsEventTaskInformation).
+ *
+ * Adds the current task_struct address on top of the generic pid/tid/comm.
+ */
+class LinuxEventTaskInformation : public EventTaskInformation {
+  public:
+    /**
+     * @brief Kernel virtual address of the current task_struct, or 0 if it
+     *        could not be resolved.
+     */
+    virtual uint64_t task_struct_address() const = 0;
+
+    // EventTaskInformation declares no (virtual) destructor, so this can't be
+    // `override`; declare our own virtual dtor.
+    virtual ~LinuxEventTaskInformation() = default;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/fwd.hh
+++ b/include/introvirt/linux/fwd.hh
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+namespace introvirt {
+
+// NOTE: the namespace is `linux_guest`, not `linux`, because GCC/Clang in
+// GNU mode predefine the object-like macro `linux` (== 1) on Linux targets,
+// which would mangle `namespace linux`. Keeping it explicit avoids needing a
+// fragile `#undef linux` in every translation unit. Mirrors `windows::`.
+namespace linux_guest {
+
+class LinuxGuest;
+class LinuxKernel;
+class LinuxProfile;
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/inject/syscall.hh
+++ b/include/introvirt/linux/inject/syscall.hh
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+/**
+ * @file syscall.hh
+ * @brief Public x86_64 Linux syscall-injection API.
+ *
+ * The injection primitive (``SystemCallInjector``) is internal; these free
+ * functions are the public surface the ``iv*`` tools (and the runner) use to
+ * drop/read guest files and launch processes. All MUST be called from within an
+ * active event handler (a vCPU stopped at a syscall boundary, with the target
+ * process as ``current``).
+ */
+
+#include <introvirt/core/fwd.hh>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace introvirt {
+namespace linux_guest {
+namespace inject {
+
+// x86_64 Linux syscall numbers (stable guest ABI).
+namespace nr {
+constexpr uint64_t read = 0;
+constexpr uint64_t write = 1;
+constexpr uint64_t open = 2;
+constexpr uint64_t close = 3;
+constexpr uint64_t lseek = 8;
+constexpr uint64_t mmap = 9;
+constexpr uint64_t munmap = 11;
+constexpr uint64_t fork = 57;
+constexpr uint64_t execve = 59;
+constexpr uint64_t openat = 257;
+} // namespace nr
+
+// mmap prot/flags + open flags (guest ABI). 'k'-prefixed to avoid clashing with
+// the host's <sys/mman.h>/<fcntl.h> macros (which would mangle these names).
+constexpr int kProtRead = 0x1;
+constexpr int kProtWrite = 0x2;
+constexpr int kProtExec = 0x4;
+constexpr int kMapPrivate = 0x2;
+constexpr int kMapAnonymous = 0x20;
+// Pre-fault the mapping at mmap() time. Without it an anonymous mmap is
+// demand-paged: the kernel returns a VA but maps no physical page until the
+// guest first touches it — so an immediate injected write_bytes() to that VA
+// hits VirtualAddressNotPresentException (the execve push_string failure in
+// the forked-child context). MAP_POPULATE makes the page present on return.
+constexpr int kMapPopulate = 0x8000;
+constexpr int kORdonly = 0x0;
+constexpr int kOWronly = 0x1;
+constexpr int kOCreat = 0x40;
+constexpr int kOTrunc = 0x200;
+constexpr int kAtFdcwd = -100;
+
+// --- low-level: each returns the raw syscall result (RAX; -errno on error) ---
+int64_t inject_mmap(Event& event, uint64_t addr, uint64_t length, int prot, int flags,
+                    int fd, uint64_t offset);
+int64_t inject_munmap(Event& event, uint64_t addr, uint64_t length);
+int64_t inject_openat(Event& event, int dirfd, uint64_t pathname_ptr, int flags, int mode);
+int64_t inject_read(Event& event, int fd, uint64_t buf_ptr, uint64_t count);
+int64_t inject_write(Event& event, int fd, uint64_t buf_ptr, uint64_t count);
+int64_t inject_close(Event& event, int fd);
+int64_t inject_fork(Event& event);
+int64_t inject_execve(Event& event, uint64_t pathname_ptr, uint64_t argv_ptr, uint64_t envp_ptr);
+
+// --- argument marshaling into guest memory ----------------------------------
+void write_bytes(Event& event, uint64_t dst, const void* src, size_t len);
+uint64_t push_string(Event& event, const std::string& data);
+uint64_t push_string_array(Event& event, const std::vector<std::string>& items);
+
+// --- high-level helpers the tools call --------------------------------------
+
+/**
+ * @brief Write host bytes to a guest file (openat O_CREAT|O_WRONLY|O_TRUNC →
+ *        write loop → close). Returns bytes written, or a negative -errno.
+ */
+int64_t write_file(Event& event, const std::string& guest_path, const void* data, size_t len,
+                   int mode = 0644);
+
+/**
+ * @brief Read a guest file into a host buffer (openat O_RDONLY → read loop →
+ *        close), up to ``max_bytes``. Throws on open failure.
+ */
+std::vector<uint8_t> read_file(Event& event, const std::string& guest_path, size_t max_bytes);
+
+/**
+ * @brief Marshal argv/envp + path into guest memory and inject execve.
+ *        Replaces the current process image — call in a child/victim context.
+ *        Returns the execve result (only returns at all on failure: -errno).
+ */
+int64_t execve(Event& event, const std::string& path, const std::vector<std::string>& argv,
+               const std::vector<std::string>& envp);
+
+} // namespace inject
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/kernel/LinuxKernel.hh
+++ b/include/introvirt/linux/kernel/LinuxKernel.hh
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/core/domain/Guest.hh> // brings OS + guest_ptr + Event
+#include <introvirt/fwd.hh>
+#include <introvirt/linux/kernel/LinuxProcess.hh>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace introvirt {
+namespace linux_guest {
+
+class LinuxProfile;
+
+/**
+ * @brief A representation of a live Linux kernel.
+ *
+ * The Linux analogue of ``nt::NtKernel``: it owns the loaded profile, the
+ * resolved KASLR slide, and the kernel identity (banner / release), and it
+ * resolves symbols to live guest virtual addresses.
+ *
+ * This is the public interface only; the implementation
+ * (``LinuxKernelImpl``) does the live-guest detection (banner scan off
+ * ``MSR_LSTAR``, profile match, slide computation) and is added in a later
+ * increment alongside the task_struct/mm_struct walking model.
+ */
+class LinuxKernel {
+  public:
+    /**
+     * @brief Kernel release string, e.g. "5.15.0-91-generic".
+     */
+    virtual const std::string& release() const = 0;
+
+    /**
+     * @brief Full Linux banner ("Linux version ...") read from the guest.
+     */
+    virtual const std::string& banner() const = 0;
+
+    /**
+     * @brief Live base address of the kernel text (``_text`` + KASLR slide).
+     */
+    virtual uint64_t base_address() const = 0;
+
+    /**
+     * @brief The KASLR slide (live base - profile link-time base).
+     */
+    virtual int64_t kaslr_slide() const = 0;
+
+    /**
+     * @brief Resolve a kernel symbol to its live guest virtual address.
+     *
+     * Applies the KASLR slide to the profile's link-time address.
+     * @throws SymbolNotFoundException if the profile lacks the symbol.
+     */
+    virtual guest_ptr<void> symbol(const std::string& name) const = 0;
+
+    /**
+     * @brief The loaded symbol/layout profile.
+     */
+    virtual const LinuxProfile& profile() const = 0;
+
+    /**
+     * @brief Enumerate the guest's processes/tasks.
+     *
+     * Walks `init_task.tasks` and snapshots pid/tgid/comm per task — the
+     * data an ivprocinfo Linux branch renders.
+     */
+    virtual std::vector<LinuxProcess> processes() const = 0;
+
+    /**
+     * @brief Physical page-directory base (CR3 value) for a process, derived
+     *        from `task_struct.mm->pgd` (a direct-map KVA) via
+     *        `page_offset_base`. Used to translate a virtual address in that
+     *        process's address space (e.g. for ivmemwatch).
+     *
+     * @return the physical PGD, or 0 for a kernel thread (mm == NULL) or if it
+     *         can't be resolved.
+     */
+    virtual uint64_t process_page_directory(uint64_t task_struct_address) const = 0;
+
+    /**
+     * @brief Resolve the running task's `task_struct` address on a vCPU.
+     *
+     * Reads the per-CPU `current_task` pointer via the kernel GS base. Used
+     * both for event process-attribution and as the event thread id (so the
+     * framework's suspend/wake syscall-return correlation keys correctly).
+     *
+     * @return the current task_struct address, or 0 if it can't be resolved.
+     */
+    virtual uint64_t current_task(const Vcpu& vcpu) const = 0;
+
+    /**
+     * @brief A CR3 that maps the kernel half of the address space.
+     *
+     * Captured at detection (when the `linux_banner` read — a kernel symbol —
+     * succeeded through it), so it reliably maps kernel memory. Use this to
+     * read kernel data (`task_struct` fields, per-CPU areas) from an event
+     * handler: at a SYSCALL-entry event the live `Vcpu` CR3 is the *user* CR3
+     * (pre-`swapgs`/`SWITCH_TO_KERNEL_CR3`) and under KPTI can't map kernel
+     * data. Backs the same reads `symbol()`/`processes()` already use.
+     */
+    virtual uint64_t page_directory() const = 0;
+
+    virtual ~LinuxKernel() = default;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/kernel/LinuxProcess.hh
+++ b/include/introvirt/linux/kernel/LinuxProcess.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief A process/task enumerated from a Linux guest.
+ *
+ * The public, OS-generic-shaped view a tool (e.g. ivprocinfo) consumes,
+ * built from a `task_struct` read via the profile offsets. Values are
+ * snapshotted at enumeration time.
+ */
+class LinuxProcess {
+  public:
+    int32_t pid() const { return pid_; }   ///< userspace PID (task_struct.tgid)
+    int32_t tid() const { return tid_; }   ///< thread id     (task_struct.pid)
+    const std::string& name() const { return name_; } ///< task_struct.comm
+    uint64_t task_struct_address() const { return task_struct_address_; }
+
+    LinuxProcess(int32_t pid, int32_t tid, std::string name, uint64_t task_struct_address)
+        : pid_(pid), tid_(tid), name_(std::move(name)),
+          task_struct_address_(task_struct_address) {}
+
+  private:
+    int32_t pid_;
+    int32_t tid_;
+    std::string name_;
+    uint64_t task_struct_address_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/linux/profile/LinuxProfile.hh
+++ b/include/introvirt/linux/profile/LinuxProfile.hh
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief Linux kernel symbol + struct-layout provider.
+ *
+ * The Windows guest model resolves symbols and struct member offsets from
+ * the PDB embedded in the kernel PE image. Linux has no in-image debug
+ * info, so the Linux model instead loads an offline-generated profile (the
+ * "SecTepe Linux ISF", produced by tools/linux/generate_isf.py from a
+ * Volatility3 ISF).
+ *
+ * Symbol addresses in the profile are the *link-time* addresses; the live
+ * KASLR slide is applied by ``LinuxKernel``, not here.
+ */
+class LinuxProfile {
+  public:
+    /**
+     * @brief Link-time address of a kernel symbol (e.g. "init_task").
+     * @return the address, or std::nullopt if the profile lacks it.
+     */
+    virtual std::optional<uint64_t> symbol(const std::string& name) const = 0;
+
+    /**
+     * @brief Byte offset of a struct member (e.g. "task_struct", "comm").
+     * @return the offset, or std::nullopt if the type/member is absent.
+     */
+    virtual std::optional<int64_t> member_offset(const std::string& type,
+                                                 const std::string& member) const = 0;
+
+    /**
+     * @brief Size in bytes of a struct, if recorded.
+     */
+    virtual std::optional<uint64_t> type_size(const std::string& type) const = 0;
+
+    /**
+     * @brief Target architecture string, e.g. "x86_64".
+     */
+    virtual const std::string& arch() const = 0;
+
+    virtual ~LinuxProfile() = default;
+
+    /**
+     * @brief Load a SecTepe Linux ISF profile from a JSON file on the host.
+     * @throws GuestDetectionException if the file is missing/unparseable.
+     */
+    static std::unique_ptr<LinuxProfile> load(const std::string& path);
+
+    /**
+     * @brief Locate + load a profile for a kernel release string.
+     *
+     * Searches the IntroVirt profile directory (e.g.
+     * ~/.introvirt/profiles/linux-<release>-<arch>.json), mirroring the
+     * Windows ``NtKernel::profile_path()`` convention.
+     *
+     * @return the profile, or nullptr if none is installed for that kernel.
+     */
+    static std::unique_ptr<LinuxProfile> load_for_release(const std::string& release,
+                                                          const std::string& arch);
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/include/introvirt/windows/event/WindowsEventTaskInformation.hh
+++ b/include/introvirt/windows/event/WindowsEventTaskInformation.hh
@@ -49,6 +49,15 @@ class WindowsEventTaskInformation final : public EventTaskInformation {
 
   private:
     nt::KPCR& kpcr_;
+    // SECTEPE: pid/tid/process_name SNAPSHOTTED at construction (while the vcpu
+    // is in its event and registers are valid). kpcr_ is a shared per-vcpu object
+    // that later events reset() to their current thread; re-reading it later
+    // (e.g. from end_injection) reads a stale/wrong current-thread pointer ->
+    // non-canonical deref -> SIGSEGV. The event's task is the thread that
+    // generated it, so the snapshot is also more correct.
+    uint64_t pid_ = 0;
+    uint64_t tid_ = 0;
+    std::string process_name_;
 };
 
 } // namespace windows

--- a/src/core/domain/DomainImpl.cc
+++ b/src/core/domain/DomainImpl.cc
@@ -22,6 +22,7 @@
 #include "core/event/EventImpl.hh"
 #include "core/event/NoOsEvent.hh"
 #include "core/event/SystemCallEventImpl.hh"
+#include "linux/LinuxGuestImpl.hh"
 #include "windows/WindowsGuestImpl.hh"
 
 #include <introvirt/core/domain/Vcpu.hh>
@@ -30,10 +31,12 @@
 #include <introvirt/core/exception/EventPollException.hh>
 #include <introvirt/core/exception/GuestDetectionException.hh>
 #include <introvirt/core/exception/InterruptedException.hh>
+#include <introvirt/core/exception/MemoryException.hh>
 #include <introvirt/core/exception/NotImplementedException.hh>
 #include <introvirt/core/syscall/SystemCall.hh>
 #include <introvirt/util/compiler.hh>
 #include <introvirt/windows/WindowsGuest.hh>
+#include <introvirt/windows/exception/IncorrectTypeException.hh>
 
 #include <log4cxx/logger.h>
 
@@ -358,6 +361,22 @@ bool DomainImpl::detect_guest() {
                         } catch (GuestDetectionException& ex) {
                             LOG4CXX_DEBUG(logger, "Failed to detect WindowsGuest: " << ex);
                         }
+
+                        // Try a Linux guest (x86_64 only for now). This only
+                        // succeeds when a matching SecTepe Linux profile is
+                        // configured ($INTROVIRT_LINUX_PROFILE) and its
+                        // linux_banner verifies against the live kernel — so it
+                        // is a no-op for Windows guests and for hosts without a
+                        // Linux profile.
+                        if (is64bit) {
+                            try {
+                                guest_ = std::make_unique<linux_guest::LinuxGuestImpl>(*this);
+                                result = true;
+                                goto done;
+                            } catch (GuestDetectionException& ex) {
+                                LOG4CXX_DEBUG(logger, "Failed to detect LinuxGuest: " << ex);
+                            }
+                        }
                     }
                 }
             }
@@ -580,6 +599,18 @@ void DomainImpl::vcpu_poller_thread(Vcpu* ivcpu, EventCallback* callback, int ef
     struct pollfd fd_entries[2];
     std::list<worker_thread_info> threads;
 
+    /*
+     * SECTEPE: count consecutive un-buildable events skipped below. A single
+     * transient skip (the expected case for the injection race) stays quiet at
+     * DEBUG, but a vcpu that keeps failing to build events is escalated to a
+     * throttled WARN so a non-transient bad state is visible even when DEBUG
+     * logging is disabled, instead of silently spinning. Reset on the first
+     * successfully built event. This counter is private to this poller thread
+     * (one per vcpu), so no synchronization is needed.
+     */
+    uint64_t consecutive_skips = 0;
+    static constexpr uint64_t kSkipWarnEvery = 1000;
+
     fd_entries[0].fd = vcpu.event_fd();
     fd_entries[0].events = POLLIN;
 
@@ -615,7 +646,81 @@ void DomainImpl::vcpu_poller_thread(Vcpu* ivcpu, EventCallback* callback, int ef
                     if (unlikely(hypervisor_event == nullptr))
                         continue;
 
-                    auto event = filter_event(std::move(hypervisor_event));
+                    /*
+                     * SECTEPE: poller-skip for racy bad reads while building the
+                     * next event.
+                     *
+                     * filter_event() eagerly materializes the current THREAD for
+                     * THIS vcpu (WindowsEventTaskInformation ctor -> KPCR::reset()
+                     * -> kernel_.thread(current_thread_ptr)). If this vcpu is
+                     * mid-context-switch, or in user mode under KPTI where
+                     * KernelDirectoryTableBase is absent and reset() falls back to
+                     * the user CR3, current_thread_address() can yield a
+                     * garbage/non-canonical pointer. Reading a THREAD/OBJECT_HEADER
+                     * through it throws IncorrectTypeException (bad type index) or a
+                     * MemoryException (e.g. VirtualAddressNotPresentException on a
+                     * non-canonical VA). This race is observable on an idle/other
+                     * vcpu while we inject a syscall (e.g. NtCreateUserProcess) on a
+                     * different vcpu; left uncaught it escapes the poller loop and
+                     * std::terminate()s the whole session.
+                     *
+                     * Such an event is, by definition, un-buildable: there is no
+                     * Event to deliver. Skip ONLY this event and keep polling.
+                     *
+                     * Scope is deliberately narrow: KPCRs are per-vcpu
+                     * (NtKernelImpl::kpcr indexes by vcpu.id()), so a failed reset()
+                     * here only touches THIS vcpu's KPCR/os_data and never the
+                     * injecting vcpu's state. The injector waits on its own
+                     * condition variable (EventImplTpl::suspend) and is woken by the
+                     * suspended-thread fast path in DomainImpl::filter_event for ITS
+                     * OWN thread; at syscall-return the injecting vcpu is in the
+                     * kernel with a valid current-thread, so that delivery does not
+                     * hit this path. Dropping a racy event on another vcpu therefore
+                     * never drops an event the injector or the tool needs to
+                     * progress.
+                     *
+                     * We catch only MemoryException and IncorrectTypeException (the
+                     * confirmed bad-guest-read families) rather than the whole
+                     * TraceableException hierarchy, so genuinely fatal control-flow
+                     * exceptions (GuestDetectionException, EventPollException, etc.)
+                     * are NOT swallowed and cannot make the loop spin silently.
+                     */
+                    std::unique_ptr<Event> event;
+                    try {
+                        event = filter_event(std::move(hypervisor_event));
+                    } catch (const MemoryException& ex) {
+                        if (unlikely(++consecutive_skips % kSkipWarnEvery == 0)) {
+                            LOG4CXX_WARN(logger,
+                                         "Vcpu " << vcpu.id() << " skipped " << consecutive_skips
+                                                 << " consecutive un-buildable events; latest (bad "
+                                                    "guest read): "
+                                                 << ex);
+                        } else {
+                            LOG4CXX_DEBUG(logger, "Vcpu " << vcpu.id()
+                                                          << " skipping un-buildable event (bad "
+                                                             "guest read): "
+                                                          << ex);
+                        }
+                        continue;
+                    } catch (const windows::IncorrectTypeException& ex) {
+                        if (unlikely(++consecutive_skips % kSkipWarnEvery == 0)) {
+                            LOG4CXX_WARN(logger,
+                                         "Vcpu " << vcpu.id() << " skipped " << consecutive_skips
+                                                 << " consecutive un-buildable events; latest (bad "
+                                                    "type index): "
+                                                 << ex);
+                        } else {
+                            LOG4CXX_DEBUG(logger, "Vcpu " << vcpu.id()
+                                                          << " skipping un-buildable event (bad "
+                                                             "type index): "
+                                                          << ex);
+                        }
+                        continue;
+                    }
+
+                    // Built an event successfully: clear the skip streak.
+                    consecutive_skips = 0;
+
                     if (!event)
                         continue;
 

--- a/src/core/event/EventImpl.hh
+++ b/src/core/event/EventImpl.hh
@@ -222,6 +222,17 @@ class EventImplTpl : public _BaseClass, public EventImpl {
     WakeAction wake(std::unique_ptr<Event>&& event) override {
         introvirt_assert(check_wakeup_ != nullptr, "");
 
+        // SECTEPE: guard an unarmed wake. `introvirt_assert` is a no-op in
+        // release builds, so when wake() runs with no `check_wakeup_` armed —
+        // a second event for the same thread arrives before the suspended
+        // entry event re-arms, or a duplicate/spurious wake — invoking the
+        // empty std::function below threw std::bad_function_call and aborted
+        // the whole session mid-trace. The Linux entry→return syscall
+        // correlation (every syscall sets will_return()) hits this on a busy
+        // guest. Treat "not armed" as PASS: let the event flow normally.
+        if (!check_wakeup_)
+            return WakeAction::PASS;
+
         WakeAction result = check_wakeup_(*event);
         if (result == WakeAction::ACCEPT) {
             std::unique_lock lock(mtx_);

--- a/src/core/injection/RegisterGuard.cc
+++ b/src/core/injection/RegisterGuard.cc
@@ -28,6 +28,21 @@ RegisterGuard::~RegisterGuard() {
     if (!original_)
         return;
 
+    // SECTEPE: this restore reads+writes the vcpu registers. During a syscall
+    // injection's stack-unwind the vcpu may be running again, so registers()
+    // would throw EBUSY ("vcpu running") — and a throw from a destructor while
+    // ALREADY unwinding calls std::terminate (the dominant residual Win11 abort,
+    // backtrace: ~RegisterGuard -> registers().cold -> _Unwind_Resume). Pause the
+    // vcpu (refcounted; a no-op net if a guard already holds it) so the restore
+    // is always on a readable vcpu, and never propagate out of this destructor.
+    bool paused_here = false;
+    try {
+        vcpu_.pause();
+        paused_here = true;
+    } catch (...) {
+        // could not pause (degraded) — best-effort restore below, still no throw
+    }
+    try {
     auto& regs = vcpu_.registers();
     regs.rsi(original_->registers().rsi());
     regs.rdi(original_->registers().rdi());
@@ -47,6 +62,15 @@ RegisterGuard::~RegisterGuard() {
     regs.r14(original_->registers().r14());
     regs.r15(original_->registers().r15());
     regs.rflags(original_->registers().rflags());
+    } catch (...) {
+        // best-effort restore; never propagate out of a destructor.
+    }
+    if (paused_here) {
+        try {
+            vcpu_.resume();
+        } catch (...) {
+        }
+    }
 }
 
 } // namespace inject

--- a/src/core/injection/VcpuPauseGuard.hh
+++ b/src/core/injection/VcpuPauseGuard.hh
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Assured Information Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/exception/CommandFailedException.hh>
+
+namespace introvirt {
+namespace inject {
+
+/**
+ * @brief RAII pause of a SINGLE vcpu (KVM_VCPU_PAUSE refcount).
+ *
+ * SECTEPE (Win11 injection). A syscall injection reads/writes the injected
+ * vcpu's registers at its ctor, begin_syscall, and cleanup. Between sequential
+ * injections (and after a nested verify_stack_present / suspend) the vcpu is
+ * RUNNING again, so those reads hit KvmVcpu::registers()'s "vcpu running" gate
+ * and throw EBUSY. The injector holds this guard during register-access regions
+ * and RELEASES it only around the parts that must EXECUTE on the guest (the
+ * nested verify_stack_present injections and the syscall's own run via
+ * suspend()), so the register accesses are always on a paused vcpu while the
+ * guest still runs the syscalls.
+ *
+ * Pauses ONLY the given vcpu, never peers (pausing peers deadlocks the heavy
+ * create). Degrades to inert if it can't pause, and never throws from its dtor.
+ */
+class VcpuPauseGuard final {
+  public:
+    explicit VcpuPauseGuard(Vcpu& vcpu) {
+        try {
+            vcpu.pause();
+            vcpu_ = &vcpu;
+        } catch (...) {
+            vcpu_ = nullptr;
+        }
+    }
+
+    ~VcpuPauseGuard() {
+        if (vcpu_ != nullptr) {
+            try {
+                vcpu_->resume();
+            } catch (...) {
+            }
+        }
+    }
+
+    VcpuPauseGuard(const VcpuPauseGuard&) = delete;
+    VcpuPauseGuard& operator=(const VcpuPauseGuard&) = delete;
+    VcpuPauseGuard(VcpuPauseGuard&&) = delete;
+    VcpuPauseGuard& operator=(VcpuPauseGuard&&) = delete;
+
+  private:
+    Vcpu* vcpu_ = nullptr;
+};
+
+} // namespace inject
+} // namespace introvirt

--- a/src/linux/LinuxGuestImpl.cc
+++ b/src/linux/LinuxGuestImpl.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxGuestImpl.hh"
+
+#include <introvirt/core/domain/Domain.hh>
+#include <introvirt/core/event/Event.hh>
+#include <introvirt/core/event/ThreadLocalEvent.hh>
+#include <introvirt/core/exception/GuestDetectionException.hh>
+#include <introvirt/core/exception/NotImplementedException.hh>
+#include <introvirt/core/exception/TraceableException.hh>
+
+#include "linux/event/LinuxEventImpl.hh"
+#include <introvirt/linux/inject/syscall.hh>
+
+namespace introvirt {
+namespace linux_guest {
+
+LinuxGuestImpl::LinuxGuestImpl(Domain& domain) : domain_(&domain) {
+    domain.pause();
+    try {
+        // LinuxKernelImpl's constructor does the detection work and throws
+        // a TraceableException (GuestDetectionException / LinuxProfileException)
+        // if this isn't a matching Linux guest.
+        kernel_.emplace(domain);
+    } catch (const TraceableException& ex) {
+        domain.resume();
+        throw GuestDetectionException(domain, ex.what());
+    }
+    domain.resume();
+}
+
+OS LinuxGuestImpl::os() const { return OS::Linux; }
+
+// x86_64 only for now; a PtrType template (32-bit) follows later.
+bool LinuxGuestImpl::x64() const { return true; }
+
+guest_ptr<void> LinuxGuestImpl::allocate(size_t& region_size, bool executable) {
+    // Inject an anonymous private mmap into the current guest thread. Must run
+    // inside an active event (ThreadLocalEvent) so a vCPU is stopped at a
+    // syscall boundary with the target process as `current`.
+    Event& event = ThreadLocalEvent::get();
+
+    const uint64_t length = (region_size + 0xFFFULL) & ~0xFFFULL;
+    int prot = inject::kProtRead | inject::kProtWrite;
+    if (executable)
+        prot |= inject::kProtExec;
+
+    const int64_t result = inject::inject_mmap(
+        event, 0, length, prot, inject::kMapPrivate | inject::kMapAnonymous | inject::kMapPopulate, -1, 0);
+
+    // mmap returns -errno in [-4095, -1] on failure.
+    if (result < 0 && result > -4096)
+        return guest_ptr<void>();
+
+    region_size = length;
+    return guest_ptr<void>(event.vcpu(), static_cast<uint64_t>(result));
+}
+
+void LinuxGuestImpl::guest_free(const guest_ptr<void>& ptr, size_t region_size) {
+    if (!ptr)
+        return;
+    try {
+        Event& event = ThreadLocalEvent::get();
+        const uint64_t length = (region_size + 0xFFFULL) & ~0xFFFULL;
+        inject::inject_munmap(event, ptr.address(), length);
+    } catch (const TraceableException&) {
+        // Best-effort free: a failed munmap leaks guest memory but must not
+        // propagate into the event loop.
+    }
+}
+
+bool LinuxGuestImpl::page_in(Event& event, uint64_t virtual_address) {
+    // Fault the page in by injecting a zero-length read against it. The kernel
+    // touches the address to validate the buffer, paging it in; the syscall's
+    // own success/failure is irrelevant. Best-effort.
+    try {
+        inject::inject_read(event, -1, virtual_address, 0);
+        return true;
+    } catch (const TraceableException&) {
+        return false;
+    }
+}
+
+std::unique_ptr<Event>
+LinuxGuestImpl::filter_event(std::unique_ptr<HypervisorEvent>&& event) {
+    return std::make_unique<LinuxEventImpl>(*this, std::move(event));
+}
+
+GuestPageFaultResult LinuxGuestImpl::handle_page_fault(uint64_t /*virtual_address*/,
+                                                       uint64_t /*page_directory*/,
+                                                       uint64_t& /*pte*/) const {
+    // Defer to the core handler's failure path until the Linux page-table
+    // walk is implemented.
+    return GuestPageFaultResult::FAILURE;
+}
+
+uint64_t LinuxGuestImpl::get_current_thread_id(const Vcpu& vcpu) const {
+    // The current task_struct address is a stable, per-thread unique id. The
+    // framework keys its suspend/wake syscall-return correlation on this
+    // (DomainImpl::suspend_event + get_current_thread_id), so returning 0 here
+    // collapses every thread onto one key and double-wakes suspended events
+    // (std::bad_function_call). Resolve it via the shared kernel resolver.
+    return kernel_ ? kernel_->current_task(vcpu) : 0;
+}
+
+LinuxKernel& LinuxGuestImpl::kernel() { return *kernel_; }
+const LinuxKernel& LinuxGuestImpl::kernel() const { return *kernel_; }
+Domain& LinuxGuestImpl::domain() { return *domain_; }
+const Domain& LinuxGuestImpl::domain() const { return *domain_; }
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/LinuxGuestImpl.hh
+++ b/src/linux/LinuxGuestImpl.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "core/domain/GuestImpl.hh"
+#include "linux/kernel/LinuxKernelImpl.hh"
+
+#include <introvirt/linux/LinuxGuest.hh>
+
+#include <memory>
+#include <optional>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief Concrete Linux guest (x86_64), implementing Guest + GuestImpl.
+ *
+ * Mirrors windows::WindowsGuestImpl. The constructor builds the
+ * LinuxKernelImpl (which performs detection) and re-raises any failure as a
+ * GuestDetectionException so DomainImpl::detect_guest() can fall through.
+ *
+ * The event-handling surface (filter_event), memory injection (allocate /
+ * guest_free) and the page-fault / current-thread resolution are stubbed
+ * for now — see docs/introvirt-linux-port.md. They are not reached yet
+ * because the detect_guest() Linux branch is wired in a later increment,
+ * once LinuxEventImpl exists. This class is compiled (and checked by the
+ * introvirt-build CI gate) ahead of that wiring.
+ */
+class LinuxGuestImpl final : public LinuxGuest, public GuestImpl {
+  public:
+    // --- Guest ---
+    OS os() const override;
+    bool x64() const override;
+    guest_ptr<void> allocate(size_t& region_size, bool executable = false) override;
+    void guest_free(const guest_ptr<void>& ptr, size_t region_size) override;
+    bool page_in(Event& event, uint64_t virtual_address) override;
+    GuestImpl& impl() override { return *this; }
+    const GuestImpl& impl() const override { return *this; }
+
+    // --- GuestImpl ---
+    std::unique_ptr<Event> filter_event(std::unique_ptr<HypervisorEvent>&& event) override;
+    GuestPageFaultResult handle_page_fault(uint64_t virtual_address, uint64_t page_directory,
+                                           uint64_t& pte) const override;
+    uint64_t get_current_thread_id(const Vcpu& vcpu) const override;
+
+    // --- LinuxGuest ---
+    LinuxKernel& kernel() override;
+    const LinuxKernel& kernel() const override;
+    Domain& domain() override;
+    const Domain& domain() const override;
+
+    explicit LinuxGuestImpl(Domain& domain);
+
+  private:
+    Domain* domain_;
+    std::optional<LinuxKernelImpl> kernel_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxEventImpl.cc
+++ b/src/linux/event/LinuxEventImpl.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxEventImpl.hh"
+
+#include <introvirt/core/event/EventType.hh>
+#include <introvirt/core/exception/InvalidMethodException.hh>
+
+namespace introvirt {
+namespace linux_guest {
+
+LinuxEventImpl::LinuxEventImpl(LinuxGuest& guest,
+                              std::unique_ptr<HypervisorEvent>&& hypervisor_event)
+    : EventImplTpl<LinuxEvent>(std::move(hypervisor_event)), guest_(guest),
+      task_info_(guest, vcpu()) {
+    // Build the syscall view for fast-syscall events (mirrors WindowsEventImpl).
+    switch (type()) {
+    case EventType::EVENT_FAST_SYSCALL:
+    case EventType::EVENT_FAST_SYSCALL_RET:
+        syscall_.emplace(*hypervisor_event_);
+        break;
+    default:
+        break;
+    }
+}
+
+SystemCallEvent& LinuxEventImpl::syscall() {
+    if (!syscall_)
+        throw InvalidMethodException();
+    return *syscall_;
+}
+
+const SystemCallEvent& LinuxEventImpl::syscall() const {
+    if (!syscall_)
+        throw InvalidMethodException();
+    return *syscall_;
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxEventImpl.hh
+++ b/src/linux/event/LinuxEventImpl.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "core/event/EventImpl.hh"
+#include "linux/event/LinuxEventTaskInformationImpl.hh"
+#include "linux/event/LinuxSystemCallEventImpl.hh"
+
+#include <introvirt/core/syscall/SystemCall.hh> // complete type for EventImplTpl::json()
+#include <introvirt/linux/LinuxGuest.hh>
+#include <introvirt/linux/event/LinuxEvent.hh>
+
+#include <memory>
+#include <optional>
+
+namespace introvirt {
+
+class HypervisorEvent;
+
+namespace linux_guest {
+
+/**
+ * @brief Concrete Linux event (mirrors windows::WindowsEventImpl).
+ *
+ * EventImplTpl<LinuxEvent> provides everything generic (vcpu/domain/type,
+ * cr/msr/exception/mem_access, json, the suspend/step machinery). This class
+ * adds the Linux-specific pieces: os_type, task(), guest(), thread_id(), and
+ * syscall() (a LinuxSystemCallEventImpl for fast-syscall events — name +
+ * number; argument decoding is later Phase 3 work).
+ */
+class LinuxEventImpl final : public EventImplTpl<LinuxEvent> {
+  public:
+    OS os_type() const override { return OS::Linux; }
+
+    LinuxEventTaskInformation& task() override { return task_info_; }
+    const LinuxEventTaskInformation& task() const override { return task_info_; }
+
+    LinuxGuest& guest() override { return guest_; }
+    const LinuxGuest& guest() const override { return guest_; }
+
+    SystemCallEvent& syscall() override;
+    const SystemCallEvent& syscall() const override;
+
+    uint64_t thread_id() const override { return task_info_.task_struct_address(); }
+
+    LinuxEventImpl(LinuxGuest& guest, std::unique_ptr<HypervisorEvent>&& hypervisor_event);
+
+  private:
+    LinuxGuest& guest_;
+    LinuxEventTaskInformationImpl task_info_;
+    std::optional<LinuxSystemCallEventImpl> syscall_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxEventTaskInformationImpl.cc
+++ b/src/linux/event/LinuxEventTaskInformationImpl.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxEventTaskInformationImpl.hh"
+
+#include "linux/kernel/LinuxTask.hh"
+
+#include <introvirt/core/arch/x86/Registers.hh>
+#include <introvirt/core/domain/Domain.hh>
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/exception/TraceableException.hh>
+#include <introvirt/linux/LinuxGuest.hh>
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+
+namespace introvirt {
+namespace linux_guest {
+
+LinuxEventTaskInformationImpl::LinuxEventTaskInformationImpl(LinuxGuest& guest, const Vcpu& vcpu) {
+    // Resolve the running task via the shared per-CPU current_task resolver
+    // (LinuxKernel::current_task). The same call backs get_current_thread_id,
+    // so event attribution and the framework's suspend/wake syscall-return
+    // keying stay consistent. Defensive: leave the zeroed placeholder on miss.
+    try {
+        const LinuxKernel& kernel = guest.kernel();
+        const uint64_t task_address = kernel.current_task(vcpu);
+        if (task_address == 0)
+            return;
+
+        // Read the task_struct fields via the KERNEL CR3, not the live vcpu
+        // CR3. At a syscall-entry event the live CR3 is the user CR3 (pre
+        // swapgs/SWITCH_TO_KERNEL_CR3); under KPTI it can't map the task_struct
+        // (kernel memory), so pid/tgid/comm would read as garbage/fail. The
+        // kernel CR3 backs the same reads `processes()` (ivprocinfo) uses.
+        const LinuxTask task(kernel, guest.domain(), kernel.page_directory(), task_address);
+        task_struct_address_ = task_address;
+        // Linux: task_struct.tgid is the userspace PID; task_struct.pid is the
+        // per-thread id. Map to the generic pid()/tid() accordingly.
+        pid_ = static_cast<uint64_t>(task.tgid());
+        tid_ = static_cast<uint64_t>(task.pid());
+        comm_ = task.comm();
+    } catch (...) {
+        // Best-effort: any read failure leaves the zeroed placeholder. Catch
+        // broadly so nothing escapes into the event loop and aborts the trace.
+    }
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxEventTaskInformationImpl.hh
+++ b/src/linux/event/LinuxEventTaskInformationImpl.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/linux/event/LinuxEventTaskInformation.hh>
+
+#include <cstdint>
+#include <string>
+
+namespace introvirt {
+
+class Vcpu;
+
+namespace linux_guest {
+
+class LinuxGuest;
+
+/**
+ * @brief Concrete current-task info for a LinuxEvent.
+ *
+ * Resolution of the running task (per-CPU `current_task` via the kernel GS
+ * base → task_struct.pid/tgid/comm using the profile offsets) is Phase 2 in
+ * docs/introvirt-linux-port.md. Until then this returns zeros / "" — an
+ * honest placeholder rather than an unvalidated guess at the per-CPU layout.
+ * The interface + wiring are in place so the event path is complete and the
+ * resolution can drop in without touching call sites.
+ */
+class LinuxEventTaskInformationImpl final : public LinuxEventTaskInformation {
+  public:
+    uint64_t pid() const override { return pid_; }
+    uint64_t tid() const override { return tid_; }
+    std::string process_name() const override { return comm_; }
+    uint64_t task_struct_address() const override { return task_struct_address_; }
+
+    LinuxEventTaskInformationImpl(LinuxGuest& guest, const Vcpu& vcpu);
+
+  private:
+    uint64_t task_struct_address_ = 0;
+    uint64_t pid_ = 0;
+    uint64_t tid_ = 0;
+    std::string comm_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxSystemCall.cc
+++ b/src/linux/event/LinuxSystemCall.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxSystemCall.hh"
+
+#include "core/event/HypervisorEvent.hh"
+#include "linux/kernel/LinuxSyscalls.hh"
+
+#include <introvirt/core/arch/x86/Registers.hh>
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/event/Event.hh>
+#include <introvirt/core/exception/TraceableException.hh>
+#include <introvirt/core/memory/guest_ptr.hh>
+#include <introvirt/util/json/json.hh>
+
+#include <cstring>
+#include <ostream>
+#include <unordered_map>
+
+namespace introvirt {
+namespace linux_guest {
+
+namespace {
+
+// --- flag/enum decoders (x86_64 Linux uapi constants, version-stable) ------
+
+void append_flag(std::string& out, const char* name) {
+    if (!out.empty())
+        out += '|';
+    out += name;
+}
+
+std::string decode_open_flags(uint64_t f) {
+    std::string s;
+    switch (f & 0x3) { // access mode (low 2 bits)
+    case 0: append_flag(s, "O_RDONLY"); break;
+    case 1: append_flag(s, "O_WRONLY"); break;
+    case 2: append_flag(s, "O_RDWR"); break;
+    default: break;
+    }
+    const std::pair<uint64_t, const char*> bits[] = {
+        {0x40, "O_CREAT"},   {0x80, "O_EXCL"},      {0x200, "O_TRUNC"},
+        {0x400, "O_APPEND"}, {0x800, "O_NONBLOCK"}, {0x4000, "O_DIRECT"},
+        {0x10000, "O_DIRECTORY"}, {0x20000, "O_NOFOLLOW"}, {0x80000, "O_CLOEXEC"},
+    };
+    for (const auto& b : bits)
+        if (f & b.first)
+            append_flag(s, b.second);
+    return s;
+}
+
+std::string decode_prot(uint64_t p) {
+    if (p == 0)
+        return "PROT_NONE";
+    std::string s;
+    if (p & 0x1) append_flag(s, "PROT_READ");
+    if (p & 0x2) append_flag(s, "PROT_WRITE");
+    if (p & 0x4) append_flag(s, "PROT_EXEC");
+    return s;
+}
+
+std::string decode_mmap_flags(uint64_t f) {
+    std::string s;
+    const std::pair<uint64_t, const char*> bits[] = {
+        {0x1, "MAP_SHARED"}, {0x2, "MAP_PRIVATE"}, {0x10, "MAP_FIXED"},
+        {0x20, "MAP_ANONYMOUS"},
+    };
+    for (const auto& b : bits)
+        if (f & b.first)
+            append_flag(s, b.second);
+    return s;
+}
+
+std::string decode_socket_domain(uint64_t d) {
+    switch (d) {
+    case 1: return "AF_UNIX";
+    case 2: return "AF_INET";
+    case 10: return "AF_INET6";
+    case 16: return "AF_NETLINK";
+    case 17: return "AF_PACKET";
+    default: return {};
+    }
+}
+
+std::string decode_socket_type(uint64_t t) {
+    switch (t & 0xff) { // low byte; SOCK_CLOEXEC/NONBLOCK live in the high bits
+    case 1: return "SOCK_STREAM";
+    case 2: return "SOCK_DGRAM";
+    case 3: return "SOCK_RAW";
+    case 5: return "SOCK_SEQPACKET";
+    default: return {};
+    }
+}
+
+int path_arg_index(const std::string& name) {
+    static const std::unordered_map<std::string, int> kPathArg = {
+        {"open", 0},      {"creat", 0},     {"stat", 0},     {"lstat", 0},
+        {"access", 0},    {"chdir", 0},     {"chmod", 0},    {"chown", 0},
+        {"lchown", 0},    {"mkdir", 0},     {"rmdir", 0},    {"unlink", 0},
+        {"readlink", 0},  {"truncate", 0},  {"execve", 0},   {"chroot", 0},
+        {"mknod", 0},     {"statfs", 0},    {"link", 0},     {"symlink", 1},
+        {"openat", 1},    {"openat2", 1},   {"newfstatat", 1}, {"unlinkat", 1},
+        {"mkdirat", 1},   {"mknodat", 1},   {"fchownat", 1}, {"fchmodat", 1},
+        {"faccessat", 1}, {"faccessat2", 1}, {"readlinkat", 1}, {"execveat", 1},
+        {"statx", 1},
+    };
+    const auto it = kPathArg.find(name);
+    return it == kPathArg.end() ? -1 : it->second;
+}
+
+std::string read_guest_cstr(const Vcpu& vcpu, uint64_t address, size_t max = 256) {
+    if (address == 0)
+        return {};
+    try {
+        guest_ptr<char[]> ptr(vcpu, address, max);
+        const char* data = ptr.get();
+        return std::string(data, ::strnlen(data, max));
+    } catch (const TraceableException&) {
+        return {}; // unmapped / unreadable — best-effort
+    }
+}
+
+} // namespace
+
+LinuxSystemCall::LinuxSystemCall(HypervisorEvent& event) {
+    const auto& registers = event.vcpu().registers();
+    number_ = static_cast<uint32_t>(registers.rax());
+    name_ = LinuxSyscalls::name(number_);
+
+    // x86_64 syscall arg registers, in order.
+    args_[0] = registers.rdi();
+    args_[1] = registers.rsi();
+    args_[2] = registers.rdx();
+    args_[3] = registers.r10();
+    args_[4] = registers.r8();
+    args_[5] = registers.r9();
+
+    const int path_index = path_arg_index(name_);
+    if (path_index >= 0) {
+        path_ = read_guest_cstr(event.vcpu(), args_[path_index]);
+        has_path_ = !path_.empty();
+    }
+
+    // Typed flag/enum decoding for the common, high-signal syscalls.
+    if (name_ == "open")
+        decoded_.emplace_back("flags", decode_open_flags(args_[1]));
+    else if (name_ == "openat")
+        decoded_.emplace_back("flags", decode_open_flags(args_[2]));
+    else if (name_ == "mmap") {
+        decoded_.emplace_back("prot", decode_prot(args_[2]));
+        decoded_.emplace_back("flags", decode_mmap_flags(args_[3]));
+    } else if (name_ == "mprotect") {
+        decoded_.emplace_back("prot", decode_prot(args_[2]));
+    } else if (name_ == "socket") {
+        auto domain = decode_socket_domain(args_[0]);
+        auto type = decode_socket_type(args_[1]);
+        if (!domain.empty())
+            decoded_.emplace_back("domain", std::move(domain));
+        if (!type.empty())
+            decoded_.emplace_back("type", std::move(type));
+    }
+}
+
+void LinuxSystemCall::handle_return_event(Event& event) {
+    // The framework carries this handler to the return event (DomainImpl);
+    // on x86_64 the syscall return value is in RAX (often a negative errno).
+    return_value_ = static_cast<int64_t>(event.vcpu().registers().rax());
+    has_return_ = true;
+}
+
+void LinuxSystemCall::write(std::ostream& os) const {
+    // Indented so the runner's ivsyscallmon shim captures these as arguments.
+    os << "    nr=" << number_;
+    for (unsigned i = 0; i < 6; ++i)
+        os << " arg" << i << "=0x" << std::hex << args_[i] << std::dec;
+    os << '\n';
+    if (has_path_)
+        os << "    path=\"" << path_ << "\"\n";
+    for (const auto& d : decoded_)
+        os << "    " << d.first << "=" << d.second << '\n';
+    if (has_return_)
+        os << "    result=" << return_value_ << '\n';
+}
+
+Json::Value LinuxSystemCall::json() const {
+    Json::Value result;
+    result["name"] = name_;
+    result["number"] = number_;
+    Json::Value args(Json::arrayValue);
+    for (unsigned i = 0; i < 6; ++i)
+        args.append(static_cast<Json::UInt64>(args_[i]));
+    result["args"] = std::move(args);
+    if (has_path_)
+        result["path"] = path_;
+    for (const auto& d : decoded_)
+        result["decoded"][d.first] = d.second;
+    if (has_return_)
+        result["return"] = static_cast<Json::Int64>(return_value_);
+    return result;
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxSystemCall.hh
+++ b/src/linux/event/LinuxSystemCall.hh
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "core/syscall/SystemCallImpl.hh"
+
+#include <introvirt/core/syscall/SystemCall.hh>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace introvirt {
+
+class Event;
+class HypervisorEvent;
+
+namespace linux_guest {
+
+/**
+ * @brief A generic Linux syscall handler (the Linux analogue of the generated
+ * WindowsSystemCall classes).
+ *
+ * Captures the x86_64 syscall ABI at entry — number in RAX, args in
+ * RDI/RSI/RDX/R10/R8/R9 — decodes pathname strings + common flag/enum
+ * arguments (open flags, mmap/mprotect prot, socket domain/type), and
+ * correlates the return value via ``handle_return_event`` (the framework
+ * carries this handler from the entry event to the return event; see
+ * DomainImpl::process). ``will_return()`` is therefore true.
+ */
+class LinuxSystemCall final : public SystemCallImpl<SystemCall> {
+  public:
+    const std::string& name() const override { return name_; }
+    bool supported() const override { return true; }
+    bool will_return() const override { return true; }
+    void handle_return_event(Event& event) override;
+
+    void write(std::ostream& os) const override;
+    Json::Value json() const override;
+
+    explicit LinuxSystemCall(HypervisorEvent& event);
+
+  private:
+    uint32_t number_ = 0;
+    std::string name_;
+    uint64_t args_[6] = {0, 0, 0, 0, 0, 0};
+    std::string path_;     // decoded pathname argument, if any
+    bool has_path_ = false;
+    // Decoded flag/enum arguments, in order (label -> human string).
+    std::vector<std::pair<std::string, std::string>> decoded_;
+    bool has_return_ = false;
+    int64_t return_value_ = 0;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/event/LinuxSystemCallEventImpl.hh
+++ b/src/linux/event/LinuxSystemCallEventImpl.hh
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "core/event/SystemCallEventImpl.hh"
+#include "linux/event/LinuxSystemCall.hh"
+#include "linux/kernel/LinuxSyscalls.hh"
+
+#include <introvirt/core/arch/x86/Registers.hh>
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/event/EventType.hh>
+#include <introvirt/core/event/SystemCallEvent.hh>
+#include <introvirt/core/syscall/SystemCall.hh>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief Linux fast-syscall event (mirrors WindowsSystemCallEventImpl).
+ *
+ * SystemCallEventImplTpl supplies instruction()/hook_return()/return_address()/
+ * impl() from the hypervisor event. This adds the Linux specifics: raw_index
+ * from RAX, name() via the LinuxSyscalls table, and a lazily-created
+ * LinuxSystemCall handler() that decodes the argument registers (+ pathname
+ * strings) — what ivsyscallmon surfaces via handler()->write()/json().
+ */
+class LinuxSystemCallEventImpl final : public SystemCallEventImplTpl<SystemCallEvent> {
+  public:
+    SystemCall* handler() override {
+        const auto* const_this = this;
+        return const_cast<SystemCall*>(const_this->handler());
+    }
+    const SystemCall* handler() const override {
+        if (!system_call_)
+            system_call_ = std::make_unique<LinuxSystemCall>(hypervisor_event_);
+        return system_call_.get();
+    }
+    std::unique_ptr<SystemCall> release_handler() override { return std::move(system_call_); }
+    void handler(std::unique_ptr<SystemCall>&& handler) override {
+        system_call_ = std::move(handler);
+    }
+
+    uint64_t raw_index() const override { return raw_index_; }
+    void raw_index(uint64_t value) override { raw_index_ = value; }
+
+    std::string name() const override {
+        return LinuxSyscalls::name(static_cast<uint32_t>(raw_index_));
+    }
+
+    explicit LinuxSystemCallEventImpl(HypervisorEvent& hypervisor_event)
+        : SystemCallEventImplTpl<SystemCallEvent>(hypervisor_event) {
+        // On x86_64 the syscall number is in RAX at the syscall instruction.
+        if (hypervisor_event.type() == EventType::EVENT_FAST_SYSCALL)
+            raw_index(hypervisor_event.vcpu().registers().rax());
+    }
+
+  private:
+    uint64_t raw_index_ = 0;
+    mutable std::unique_ptr<SystemCall> system_call_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/injection/LinuxInject.cc
+++ b/src/linux/injection/LinuxInject.cc
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "SystemCallInjector.hh"
+
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/exception/TraceableException.hh>
+#include <introvirt/core/memory/guest_ptr.hh>
+#include <introvirt/linux/inject/syscall.hh>
+
+#include <algorithm>
+#include <cstring>
+
+namespace introvirt {
+namespace linux_guest {
+namespace inject {
+
+namespace {
+// A Linux syscall error is a negative return in [-4095, -1].
+inline bool is_error(int64_t r) { return r < 0 && r > -4096; }
+inline uint64_t page_round(uint64_t n) { return (n + 0xFFFULL) & ~0xFFFULL; }
+} // namespace
+
+int64_t inject_mmap(Event& event, uint64_t addr, uint64_t length, int prot, int flags,
+                    int fd, uint64_t offset) {
+    return SystemCallInjector(event, nr::mmap, addr, length,
+                              static_cast<uint64_t>(prot), static_cast<uint64_t>(flags),
+                              static_cast<uint64_t>(static_cast<int64_t>(fd)), offset)
+        .call();
+}
+
+int64_t inject_munmap(Event& event, uint64_t addr, uint64_t length) {
+    return SystemCallInjector(event, nr::munmap, addr, length).call();
+}
+
+int64_t inject_openat(Event& event, int dirfd, uint64_t pathname_ptr, int flags, int mode) {
+    return SystemCallInjector(event, nr::openat,
+                              static_cast<uint64_t>(static_cast<int64_t>(dirfd)),
+                              pathname_ptr, static_cast<uint64_t>(flags),
+                              static_cast<uint64_t>(mode))
+        .call();
+}
+
+int64_t inject_read(Event& event, int fd, uint64_t buf_ptr, uint64_t count) {
+    return SystemCallInjector(event, nr::read, static_cast<uint64_t>(fd), buf_ptr, count).call();
+}
+
+int64_t inject_write(Event& event, int fd, uint64_t buf_ptr, uint64_t count) {
+    return SystemCallInjector(event, nr::write, static_cast<uint64_t>(fd), buf_ptr, count).call();
+}
+
+int64_t inject_close(Event& event, int fd) {
+    return SystemCallInjector(event, nr::close, static_cast<uint64_t>(fd)).call();
+}
+
+int64_t inject_fork(Event& event) { return SystemCallInjector(event, nr::fork).call(); }
+
+int64_t inject_execve(Event& event, uint64_t pathname_ptr, uint64_t argv_ptr,
+                      uint64_t envp_ptr) {
+    // execve replaces the process image and does not return to this thread on
+    // success — use the no-return injection path (no suspend-for-return, no
+    // register restore). On failure the kernel resumes the caller normally; the
+    // child simply continues and is reaped, which is acceptable for launch.
+    return SystemCallInjector(event, nr::execve, pathname_ptr, argv_ptr, envp_ptr).call_no_return();
+}
+
+void write_bytes(Event& event, uint64_t dst, const void* src, size_t len) {
+    if (len == 0)
+        return;
+    // Guest memory is mapped into the host; writing through .get() modifies it.
+    guest_ptr<uint8_t[]> p(event.vcpu(), dst, len);
+    std::memcpy(p.get(), src, len);
+}
+
+uint64_t push_string(Event& event, const std::string& data) {
+    const size_t len = data.size() + 1; // include trailing NUL
+    int64_t addr =
+        inject_mmap(event, 0, page_round(len), kProtRead | kProtWrite,
+                    kMapPrivate | kMapAnonymous | kMapPopulate, -1, 0);
+    if (is_error(addr) || addr == 0)
+        return 0;
+    write_bytes(event, static_cast<uint64_t>(addr), data.c_str(), len);
+    return static_cast<uint64_t>(addr);
+}
+
+uint64_t push_string_array(Event& event, const std::vector<std::string>& items) {
+    std::vector<uint64_t> ptrs;
+    ptrs.reserve(items.size() + 1);
+    for (const auto& s : items) {
+        uint64_t a = push_string(event, s);
+        if (a == 0)
+            return 0;
+        ptrs.push_back(a);
+    }
+    ptrs.push_back(0); // NULL terminator
+
+    const size_t bytes = ptrs.size() * sizeof(uint64_t);
+    int64_t arr =
+        inject_mmap(event, 0, page_round(bytes), kProtRead | kProtWrite,
+                    kMapPrivate | kMapAnonymous | kMapPopulate, -1, 0);
+    if (is_error(arr) || arr == 0)
+        return 0;
+    write_bytes(event, static_cast<uint64_t>(arr), ptrs.data(), bytes);
+    return static_cast<uint64_t>(arr);
+}
+
+// ---------------------------------------------------------------- high-level
+
+int64_t write_file(Event& event, const std::string& guest_path, const void* data, size_t len,
+                   int mode) {
+    const uint64_t path_ptr = push_string(event, guest_path);
+    if (path_ptr == 0)
+        return -1;
+    const int64_t fd =
+        inject_openat(event, kAtFdcwd, path_ptr, kOWronly | kOCreat | kOTrunc, mode);
+    if (is_error(fd))
+        return fd;
+
+    // Stage a guest transfer buffer; copy host chunks in and inject write().
+    constexpr uint64_t kChunk = 1u << 20; // 1 MiB
+    const int64_t buf = inject_mmap(event, 0, page_round(kChunk), kProtRead | kProtWrite,
+                                    kMapPrivate | kMapAnonymous | kMapPopulate, -1, 0);
+    if (is_error(buf)) {
+        inject_close(event, static_cast<int>(fd));
+        return buf;
+    }
+
+    const auto* p = static_cast<const uint8_t*>(data);
+    int64_t total = 0;
+    while (static_cast<size_t>(total) < len) {
+        const uint64_t n = std::min<uint64_t>(kChunk, len - total);
+        write_bytes(event, static_cast<uint64_t>(buf), p + total, n);
+        const int64_t w = inject_write(event, static_cast<int>(fd), static_cast<uint64_t>(buf), n);
+        if (is_error(w) || w == 0)
+            break;
+        total += w;
+    }
+
+    inject_munmap(event, static_cast<uint64_t>(buf), page_round(kChunk));
+    inject_close(event, static_cast<int>(fd));
+    return total;
+}
+
+std::vector<uint8_t> read_file(Event& event, const std::string& guest_path, size_t max_bytes) {
+    std::vector<uint8_t> out;
+    const uint64_t path_ptr = push_string(event, guest_path);
+    if (path_ptr == 0)
+        return out;
+    const int64_t fd = inject_openat(event, kAtFdcwd, path_ptr, kORdonly, 0);
+    if (is_error(fd))
+        return out;
+
+    constexpr uint64_t kChunk = 1u << 20; // 1 MiB
+    const int64_t buf = inject_mmap(event, 0, page_round(kChunk), kProtRead | kProtWrite,
+                                    kMapPrivate | kMapAnonymous | kMapPopulate, -1, 0);
+    if (is_error(buf)) {
+        inject_close(event, static_cast<int>(fd));
+        return out;
+    }
+
+    while (out.size() < max_bytes) {
+        const uint64_t want = std::min<uint64_t>(kChunk, max_bytes - out.size());
+        const int64_t r = inject_read(event, static_cast<int>(fd), static_cast<uint64_t>(buf), want);
+        if (is_error(r) || r == 0)
+            break;
+        guest_ptr<uint8_t[]> gp(event.vcpu(), static_cast<uint64_t>(buf), static_cast<size_t>(r));
+        const uint8_t* hp = gp.get();
+        out.insert(out.end(), hp, hp + r);
+    }
+
+    inject_munmap(event, static_cast<uint64_t>(buf), page_round(kChunk));
+    inject_close(event, static_cast<int>(fd));
+    return out;
+}
+
+int64_t execve(Event& event, const std::string& path, const std::vector<std::string>& argv,
+               const std::vector<std::string>& envp) {
+    const uint64_t path_ptr = push_string(event, path);
+    const uint64_t argv_ptr = push_string_array(event, argv);
+    const uint64_t envp_ptr = push_string_array(event, envp);
+    if (path_ptr == 0 || argv_ptr == 0 || envp_ptr == 0)
+        return -1;
+    return inject_execve(event, path_ptr, argv_ptr, envp_ptr);
+}
+
+} // namespace inject
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/injection/SystemCallInjector.hh
+++ b/src/linux/injection/SystemCallInjector.hh
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "core/domain/DomainImpl.hh"
+#include "core/domain/VcpuImpl.hh"
+#include "core/event/EventImpl.hh"
+#include "core/injection/RegisterGuard.hh"
+
+#include <introvirt/core/domain/Domain.hh>
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/event/Event.hh>
+#include <introvirt/core/event/EventType.hh>
+
+#include <cstdint>
+
+namespace introvirt {
+namespace linux_guest {
+namespace inject {
+
+/**
+ * @brief Inject one x86_64 Linux system call into the current guest thread.
+ *
+ * The Linux ABI makes this much simpler than the Windows injector: the syscall
+ * number goes in RAX, up to six arguments in RDI/RSI/RDX/R10/R8/R9, and the
+ * result comes back in RAX (a negative value in [-4095, -1] is ``-errno``).
+ * There is no SSDT index translation, no TEB LastStatus to preserve, and no
+ * stack arguments for <= 6 args.
+ *
+ * Mechanism (mirrors ``windows::inject::SystemCallInjector``): a
+ * :class:`RegisterGuard` snapshots the vCPU, we set the syscall registers and
+ * force a SYSCALL with ``Vcpu::inject_syscall()``, then suspend the event until
+ * the matching ``EVENT_FAST_SYSCALL_RET`` fires; RAX at the return is the
+ * result. The guard restores the original registers as the call unwinds, so the
+ * guest thread resumes exactly where it was.
+ *
+ * MUST be called from within an active event handler (so a vCPU is stopped at a
+ * syscall boundary and ``current`` is the target process).
+ */
+class SystemCallInjector final {
+  public:
+    SystemCallInjector(Event& event, uint64_t syscall_number, uint64_t arg0 = 0,
+                       uint64_t arg1 = 0, uint64_t arg2 = 0, uint64_t arg3 = 0,
+                       uint64_t arg4 = 0, uint64_t arg5 = 0)
+        : event_(event), nr_(syscall_number),
+          args_{arg0, arg1, arg2, arg3, arg4, arg5} {}
+
+    /**
+     * @brief Run the injected syscall and return its result (RAX).
+     * @return The raw syscall return; negative values in [-4095,-1] are -errno.
+     */
+    int64_t call() {
+        auto& vcpu = static_cast<VcpuImpl&>(event_.vcpu());
+        auto& regs = vcpu.registers();
+        auto& domain = static_cast<DomainImpl&>(event_.domain());
+
+        // Snapshot + auto-restore the vCPU around the injection.
+        introvirt::inject::RegisterGuard guard(vcpu);
+
+        // Linux x86_64 syscall ABI.
+        regs.rax(nr_);
+        regs.rdi(args_[0]);
+        regs.rsi(args_[1]);
+        regs.rdx(args_[2]);
+        regs.r10(args_[3]);
+        regs.r8(args_[4]);
+        regs.r9(args_[5]);
+
+        domain.start_injection(event_);
+        int64_t result = 0;
+        try {
+            vcpu.syscall_injection_start();
+            // Force a SYSCALL at the current RIP. As in KVM the RIP changes, so
+            // it fires exactly once. Must not be done while already in kernel.
+            vcpu.inject_syscall();
+
+            std::unique_ptr<Event> return_event =
+                event_.impl().suspend([](const Event& e) {
+                    return e.type() == EventType::EVENT_FAST_SYSCALL_RET
+                               ? WakeAction::ACCEPT
+                               : WakeAction::PASS;
+                });
+            event_.impl().injection_performed(true);
+
+            // At the return event the live vCPU RAX holds the syscall result.
+            result = static_cast<int64_t>(vcpu.registers().rax());
+            (void)return_event; // not needed beyond resuming the thread
+
+        } catch (...) {
+            vcpu.syscall_injection_end();
+            domain.end_injection(event_);
+            throw;
+        }
+        vcpu.syscall_injection_end();
+        domain.end_injection(event_);
+        return result;
+    }
+
+    /**
+     * @brief Inject a syscall that never returns to the original context.
+     *
+     * For ``execve``: on success the kernel discards the calling thread's
+     * register file and user mapping and resumes at the new image's entry point,
+     * so there is no ``EVENT_FAST_SYSCALL_RET`` matching the *old* thread to wait
+     * for. The normal ``call()`` would (a) block in ``suspend()`` for a return
+     * event that never pairs with this injection, and (b) on unwind let the
+     * ``RegisterGuard`` write the snapshot's registers back over the freshly
+     * loaded new-image state — corrupting the launched program (it dies right
+     * after start). So here we set up the syscall, force the SYSCALL entry, then
+     * ``release()`` the guard (keep the kernel-entry registers) and return
+     * WITHOUT suspending: the next ``complete_event`` resumes the vCPU straight
+     * into the execve body, which runs to completion in the new image.
+     *
+     * @note Only meaningful for image-replacing / no-return syscalls. The result
+     *       is unobservable by design; returns 0.
+     */
+    int64_t call_no_return() {
+        auto& vcpu = static_cast<VcpuImpl&>(event_.vcpu());
+        auto& regs = vcpu.registers();
+        auto& domain = static_cast<DomainImpl&>(event_.domain());
+
+        introvirt::inject::RegisterGuard guard(vcpu);
+
+        regs.rax(nr_);
+        regs.rdi(args_[0]);
+        regs.rsi(args_[1]);
+        regs.rdx(args_[2]);
+        regs.r10(args_[3]);
+        regs.r8(args_[4]);
+        regs.r9(args_[5]);
+
+        domain.start_injection(event_);
+        try {
+            vcpu.syscall_injection_start();
+            // Emulate the SYSCALL instruction: this lands the vCPU at the kernel
+            // syscall entry (LSTAR) with our rax/args in place. The body runs on
+            // the next vCPU resume.
+            vcpu.inject_syscall();
+            event_.impl().injection_performed(true);
+            // Keep the kernel-entry register state: do NOT restore the snapshot,
+            // or execve's new image gets clobbered on resume.
+            guard.release();
+        } catch (...) {
+            vcpu.syscall_injection_end();
+            domain.end_injection(event_);
+            throw;
+        }
+        vcpu.syscall_injection_end();
+        domain.end_injection(event_);
+        return 0;
+    }
+
+  private:
+    Event& event_;
+    uint64_t nr_;
+    uint64_t args_[6];
+};
+
+} // namespace inject
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxKernelImpl.cc
+++ b/src/linux/kernel/LinuxKernelImpl.cc
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxKernelImpl.hh"
+
+#include "linux/kernel/LinuxProcessList.hh"
+#include "linux/kernel/LinuxTask.hh"
+
+#include <introvirt/core/arch/x86/Msr.hh>
+#include <introvirt/core/arch/x86/PageDirectory.hh>
+#include <introvirt/core/arch/x86/Registers.hh>
+#include <introvirt/core/domain/Domain.hh>
+#include <introvirt/core/domain/Vcpu.hh>
+#include <introvirt/core/exception/GuestDetectionException.hh>
+#include <introvirt/core/exception/TraceableException.hh>
+#include <introvirt/core/exception/VirtualAddressNotPresentException.hh>
+#include <introvirt/core/memory/guest_ptr.hh>
+
+#include <cstdlib>
+#include <cstring>
+
+namespace introvirt {
+namespace linux_guest {
+
+namespace {
+// Read up to `max` bytes of a NUL-terminated string from the guest.
+// guest_ptr<char[]> (the array form) takes a length and maps a buffer; the
+// non-array guest_ptr<char> only has 1-/2-arg resets and would not compile.
+std::string read_guest_cstr(const Vcpu& vcpu, uint64_t address, size_t max) {
+    guest_ptr<char[]> ptr(vcpu, address, max);
+    const char* data = ptr.get();
+    const size_t len = ::strnlen(data, max);
+    return std::string(data, len);
+}
+
+// x86_64 canonical kernel half — kernel virtual addresses sit above this.
+constexpr uint64_t kKernelHalf = 0xffff800000000000ULL;
+bool is_kernel_address(uint64_t address) { return address >= kKernelHalf; }
+} // namespace
+
+LinuxKernelImpl::LinuxKernelImpl(Domain& domain) : domain_(&domain) {
+    // Prefer a vcpu that is currently handling an event (its registers are
+    // the freshest), else fall back to vcpu 0.
+    Vcpu* vcpu = &domain.vcpu(0);
+    for (uint32_t i = 0; i < domain.vcpu_count(); ++i) {
+        Vcpu& v = domain.vcpu(i);
+        if (v.handling_event()) {
+            vcpu = &v;
+            break;
+        }
+    }
+
+    const auto& registers = vcpu->registers();
+    const uint64_t lstar = registers.msr(x86::Msr::MSR_LSTAR);
+    if (lstar == 0)
+        throw GuestDetectionException(domain, "MSR_LSTAR is 0 (kernel not booted yet?)");
+    page_directory_ = registers.cr3();
+
+    // The profile is selected out-of-band: the runner/operator points
+    // $INTROVIRT_LINUX_PROFILE at the SecTepe ISF for this guest's kernel.
+    // Without one we have no symbols, so Linux simply isn't detected here
+    // (the runner's hybrid path still handles the guest).
+    const char* profile_path = std::getenv("INTROVIRT_LINUX_PROFILE");
+    if (profile_path == nullptr)
+        throw GuestDetectionException(
+            domain, "INTROVIRT_LINUX_PROFILE is unset; no Linux profile to match");
+
+    // LinuxProfile::load throws LinuxProfileException on a broken file.
+    profile_ = LinuxProfile::load(profile_path);
+
+    const auto entry = profile_->symbol("entry_SYSCALL_64");
+    if (!entry)
+        throw GuestDetectionException(domain, "profile is missing entry_SYSCALL_64");
+
+    // LSTAR is the live address of entry_SYSCALL_64; the difference from the
+    // profile's link-time address is the KASLR slide applied to all symbols.
+    kaslr_slide_ = static_cast<int64_t>(lstar) - static_cast<int64_t>(*entry);
+
+    // Confirm this really is the matching Linux kernel: read linux_banner at
+    // its slid address and require the canonical "Linux version " prefix.
+    const auto banner_link = profile_->symbol("linux_banner");
+    if (!banner_link)
+        throw GuestDetectionException(domain, "profile is missing linux_banner");
+    const uint64_t banner_address = *banner_link + static_cast<uint64_t>(kaslr_slide_);
+
+    try {
+        const std::string banner = read_guest_cstr(*vcpu, banner_address, 256);
+        static const std::string kPrefix = "Linux version ";
+        if (banner.rfind(kPrefix, 0) != 0)
+            throw GuestDetectionException(
+                domain, "linux_banner mismatch at slid address: '" +
+                            banner.substr(0, 32) + "'");
+        banner_ = banner;
+        const std::string rest = banner.substr(kPrefix.size());
+        release_ = rest.substr(0, rest.find(' '));
+    } catch (const VirtualAddressNotPresentException&) {
+        throw GuestDetectionException(domain, "linux_banner address is not mapped");
+    }
+
+    const auto text = profile_->symbol("_text");
+    base_address_ = (text ? *text : 0) + static_cast<uint64_t>(kaslr_slide_);
+
+    // Pin a STABLE kernel-mapping CR3 for event-time reads. `page_directory_`
+    // so far is whatever CR3 was live at construction — fine for the detection
+    // reads above, but it may be a short-lived process's CR3 that later gets
+    // freed, after which event-handler kernel reads (current_task, task_struct
+    // fields) fail and attribution collapses to 0:0. `init_top_pgt` (the
+    // kernel's top-level page table; `init_level4_pgt`/`swapper_pg_dir` on
+    // older kernels) never moves — its PHYSICAL address IS the kernel CR3.
+    // Translate its VA once here and use that for every subsequent read.
+    for (const char* sym : {"init_top_pgt", "init_level4_pgt"}) {
+        const auto link = profile_->symbol(sym);
+        if (!link)
+            continue;
+        try {
+            const uint64_t va = *link + static_cast<uint64_t>(kaslr_slide_);
+            const uint64_t pa = domain.page_directory().translate(va, page_directory_);
+            if (pa != 0) {
+                page_directory_ = pa & ~0xfffULL; // CR3 is page-aligned
+                break;
+            }
+        } catch (const TraceableException&) {
+            // Couldn't translate — keep the construction-time CR3.
+        }
+    }
+}
+
+const std::string& LinuxKernelImpl::release() const { return release_; }
+const std::string& LinuxKernelImpl::banner() const { return banner_; }
+uint64_t LinuxKernelImpl::base_address() const { return base_address_; }
+int64_t LinuxKernelImpl::kaslr_slide() const { return kaslr_slide_; }
+const LinuxProfile& LinuxKernelImpl::profile() const { return *profile_; }
+uint64_t LinuxKernelImpl::page_directory() const { return page_directory_; }
+
+guest_ptr<void> LinuxKernelImpl::symbol(const std::string& name) const {
+    const auto link = profile_->symbol(name);
+    if (!link)
+        throw GuestDetectionException(*domain_, "symbol not in Linux profile: " + name);
+    const uint64_t address = *link + static_cast<uint64_t>(kaslr_slide_);
+    return guest_ptr<void>(*domain_, address, page_directory_);
+}
+
+std::vector<LinuxProcess> LinuxKernelImpl::processes() const {
+    std::vector<LinuxProcess> result;
+    LinuxProcessList list(*this, *domain_, page_directory_);
+    for (const LinuxTask& task : list.tasks()) {
+        result.emplace_back(task.tgid(), task.pid(), task.comm(), task.address());
+    }
+    return result;
+}
+
+uint64_t LinuxKernelImpl::process_page_directory(uint64_t task_address) const {
+    const auto mm_off = profile_->member_offset("task_struct", "mm");
+    const auto pgd_off = profile_->member_offset("mm_struct", "pgd");
+    const auto page_offset_base = profile_->symbol("page_offset_base");
+    if (!mm_off || !pgd_off || !page_offset_base)
+        return 0;
+
+    try {
+        // task_struct.mm — NULL for kernel threads (no userspace address space).
+        const uint64_t mm =
+            *guest_ptr<uint64_t>(*domain_, task_address + *mm_off, page_directory_);
+        if (mm == 0)
+            return 0;
+
+        // mm_struct.pgd is a direct-map kernel virtual address; the CR3 value
+        // is its physical address = pgd_kva - page_offset_base (the live,
+        // KASLR-randomised direct-map base, read from the slid symbol).
+        const uint64_t pgd_kva =
+            *guest_ptr<uint64_t>(*domain_, mm + *pgd_off, page_directory_);
+        const uint64_t direct_map_base = *guest_ptr<uint64_t>(
+            *domain_, *page_offset_base + static_cast<uint64_t>(kaslr_slide_), page_directory_);
+        if (pgd_kva <= direct_map_base)
+            return 0;
+        return pgd_kva - direct_map_base;
+    } catch (const TraceableException&) {
+        return 0;
+    }
+}
+
+uint64_t LinuxKernelImpl::current_task(const Vcpu& vcpu) const {
+    // `current_task` is a per-CPU pointer; its profile address is the offset
+    // within the per-CPU area (no KASLR slide — that applies to absolute
+    // symbols, not per-CPU offsets).
+    const auto ct_off = profile_->symbol("current_task");
+    if (!ct_off)
+        return 0;
+    const auto comm_off = profile_->member_offset("task_struct", "comm");
+
+    const auto& registers = vcpu.registers();
+
+    // CR3 candidates for reading the (kernel-resident) per-CPU `current_task`:
+    //  1. the live vcpu CR3 — correct when the guest has NO KPTI (user CR3 maps
+    //     the kernel) or the event fired after SWITCH_TO_KERNEL_CR3.
+    //  2. `page_directory_` — the CR3 captured at detection, PROVEN to map the
+    //     kernel (the `linux_banner` read succeeded through it). Under KPTI the
+    //     live CR3 at syscall entry is the *user* CR3 and can't read kernel
+    //     data, so this kernel-mapping CR3 is the fallback that actually works.
+    //     (Validated on-host: with only the live CR3, attribution stayed 0:0.)
+    const uint64_t pgds[] = {registers.cr3(), page_directory_};
+
+    // The kernel per-CPU base lives in GS, but a syscall-entry event can fire
+    // either side of `swapgs` — so the kernel base is in MSR_KERNEL_GS_BASE OR
+    // MSR_GS_BASE. Try both; validate each candidate by requiring a printable
+    // first comm byte, so a wrong base (→ a garbage pointer, or the idle/user
+    // value) is rejected rather than mis-attributed.
+    const uint64_t bases[] = {
+        registers.msr(x86::Msr::MSR_KERNEL_GS_BASE),
+        registers.msr(x86::Msr::MSR_GS_BASE),
+    };
+    for (const uint64_t pgd : pgds) {
+        if (pgd == 0)
+            continue;
+        for (const uint64_t base : bases) {
+            if (!is_kernel_address(base))
+                continue;
+            try {
+                const uint64_t task = *guest_ptr<uint64_t>(*domain_, base + *ct_off, pgd);
+                if (!is_kernel_address(task))
+                    continue;
+                if (comm_off) {
+                    guest_ptr<char[]> comm(*domain_, task + *comm_off, pgd, 16);
+                    const auto c0 = static_cast<unsigned char>(comm.get()[0]);
+                    if (c0 <= 0x20 || c0 >= 0x7f)
+                        continue; // empty/garbage comm — not a real task
+                }
+                return task;
+            } catch (...) {
+                // Read failed (page not present via this CR3, transient KVMi
+                // EAGAIN, etc.) — MUST catch broadly so it can't escape into
+                // the event loop; try the next base/CR3.
+            }
+        }
+    }
+    return 0;
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxKernelImpl.hh
+++ b/src/linux/kernel/LinuxKernelImpl.hh
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+#include <introvirt/linux/profile/LinuxProfile.hh>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace introvirt {
+
+class Domain;
+
+namespace linux_guest {
+
+/**
+ * @brief Concrete LinuxKernel: detection + symbol resolution.
+ *
+ * Detection (in the constructor, throwing GuestDetectionException on miss):
+ *   1. read MSR_LSTAR — the live address of entry_SYSCALL_64;
+ *   2. load the profile named by $INTROVIRT_LINUX_PROFILE;
+ *   3. KASLR slide = LSTAR - profile("entry_SYSCALL_64");
+ *   4. confirm it's really Linux by reading `linux_banner` at its slid
+ *      address and checking the "Linux version " prefix;
+ *   5. parse the release out of the banner.
+ *
+ * x86_64 only for now (no PtrType template yet) — see
+ * docs/introvirt-linux-port.md.
+ *
+ * NOTE: the constructor is not yet reached in production — the
+ * DomainImpl::detect_guest() Linux branch is wired in a later increment,
+ * once LinuxEventImpl exists. This unit is built (and compile-checked by the
+ * introvirt-build CI gate) ahead of that.
+ */
+class LinuxKernelImpl final : public LinuxKernel {
+  public:
+    const std::string& release() const override;
+    const std::string& banner() const override;
+    uint64_t base_address() const override;
+    int64_t kaslr_slide() const override;
+    guest_ptr<void> symbol(const std::string& name) const override;
+    const LinuxProfile& profile() const override;
+    std::vector<LinuxProcess> processes() const override;
+    uint64_t process_page_directory(uint64_t task_struct_address) const override;
+    uint64_t current_task(const Vcpu& vcpu) const override;
+    uint64_t page_directory() const override;
+
+    explicit LinuxKernelImpl(Domain& domain);
+
+  private:
+    Domain* domain_;
+    std::unique_ptr<LinuxProfile> profile_;
+    int64_t kaslr_slide_ = 0;
+    uint64_t base_address_ = 0;
+    uint64_t page_directory_ = 0;
+    std::string release_;
+    std::string banner_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxProcessList.cc
+++ b/src/linux/kernel/LinuxProcessList.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxProcessList.hh"
+
+#include "linux/profile/LinuxProfileImpl.hh" // LinuxProfileException
+
+#include <introvirt/core/domain/Domain.hh>
+#include <introvirt/core/exception/VirtualAddressNotPresentException.hh>
+#include <introvirt/core/memory/guest_ptr.hh>
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+#include <introvirt/linux/profile/LinuxProfile.hh>
+
+namespace introvirt {
+namespace linux_guest {
+
+namespace {
+
+// Upper bound on tasks walked, so a corrupt/cyclic list can't loop forever.
+constexpr size_t kMaxTasks = 100000;
+
+int64_t require_offset(const LinuxProfile& profile, const char* type, const char* member) {
+    const auto off = profile.member_offset(type, member);
+    if (!off)
+        throw LinuxProfileException(std::string(type) + "." + member +
+                                    " missing from Linux profile");
+    return *off;
+}
+
+uint64_t read_ptr(const Domain& domain, uint64_t address, uint64_t page_directory) {
+    guest_ptr<uint64_t> ptr(domain, address, page_directory);
+    return *ptr;
+}
+
+} // namespace
+
+LinuxProcessList::LinuxProcessList(const LinuxKernel& kernel, const Domain& domain,
+                                   uint64_t page_directory)
+    : kernel_(kernel), domain_(domain), page_directory_(page_directory) {}
+
+std::vector<LinuxTask> LinuxProcessList::tasks() const {
+    std::vector<LinuxTask> result;
+
+    const LinuxProfile& profile = kernel_.profile();
+    const int64_t tasks_off = require_offset(profile, "task_struct", "tasks");
+    const int64_t next_off = require_offset(profile, "list_head", "next");
+
+    // The list_head embedded in init_task is the anchor; the walk ends when
+    // we come back round to it.
+    const uint64_t anchor = kernel_.symbol("init_task").address() + tasks_off;
+
+    try {
+        uint64_t node = read_ptr(domain_, anchor + next_off, page_directory_);
+        size_t guard = 0;
+        while (node != anchor && node != 0 && guard++ < kMaxTasks) {
+            const uint64_t task_address = node - tasks_off;
+            result.emplace_back(kernel_, domain_, page_directory_, task_address);
+            node = read_ptr(domain_, node + next_off, page_directory_);
+        }
+    } catch (const VirtualAddressNotPresentException&) {
+        // Truncate the walk at the first unmapped node rather than fail.
+    }
+
+    return result;
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxProcessList.hh
+++ b/src/linux/kernel/LinuxProcessList.hh
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "linux/kernel/LinuxTask.hh"
+
+#include <cstdint>
+#include <vector>
+
+namespace introvirt {
+
+class Domain;
+
+namespace linux_guest {
+
+class LinuxKernel;
+
+/**
+ * @brief Enumerates the guest's tasks by walking `init_task.tasks`.
+ *
+ * The kernel keeps every task on a doubly-linked `list_head` rooted at
+ * `init_task.tasks`. Starting at `init_task` and following `.next` until we
+ * return to the root yields one node per task; each node sits at
+ * `task_struct + offsetof(task_struct, tasks)`, so the task_struct address is
+ * `node - tasks_offset`. This is the standard Volatility-style walk and the
+ * foundation for `ivprocinfo` on Linux.
+ *
+ * Reads are defensive: an unmapped node or a cycle longer than a sane bound
+ * ends the walk rather than throwing/looping forever.
+ */
+class LinuxProcessList {
+  public:
+    LinuxProcessList(const LinuxKernel& kernel, const Domain& domain, uint64_t page_directory);
+
+    /**
+     * @brief All tasks reachable from init_task.tasks (excluding init_task).
+     */
+    std::vector<LinuxTask> tasks() const;
+
+  private:
+    const LinuxKernel& kernel_;
+    const Domain& domain_;
+    uint64_t page_directory_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxSyscalls.cc
+++ b/src/linux/kernel/LinuxSyscalls.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxSyscalls.hh"
+
+#include <unordered_map>
+
+namespace introvirt {
+namespace linux_guest {
+
+std::string LinuxSyscalls::name(uint32_t number) {
+    // Curated, version-stable x86_64 syscall numbers (linux/arch/x86/entry/
+    // syscalls/syscall_64.tbl). Focused on the file / network / process /
+    // exec calls that matter for behavioural analysis.
+    static const std::unordered_map<uint32_t, const char*> kTable = {
+        {0, "read"},          {1, "write"},          {2, "open"},
+        {3, "close"},         {4, "stat"},           {5, "fstat"},
+        {6, "lstat"},         {7, "poll"},           {8, "lseek"},
+        {9, "mmap"},          {10, "mprotect"},      {11, "munmap"},
+        {12, "brk"},          {13, "rt_sigaction"},  {14, "rt_sigprocmask"},
+        {16, "ioctl"},        {17, "pread64"},       {18, "pwrite64"},
+        {19, "readv"},        {20, "writev"},        {21, "access"},
+        {22, "pipe"},         {23, "select"},        {32, "dup"},
+        {33, "dup2"},         {35, "nanosleep"},     {39, "getpid"},
+        {41, "socket"},       {42, "connect"},       {43, "accept"},
+        {44, "sendto"},       {45, "recvfrom"},      {46, "sendmsg"},
+        {47, "recvmsg"},      {48, "shutdown"},      {49, "bind"},
+        {50, "listen"},       {51, "getsockname"},   {52, "getpeername"},
+        {53, "socketpair"},   {54, "setsockopt"},    {55, "getsockopt"},
+        {56, "clone"},        {57, "fork"},          {58, "vfork"},
+        {59, "execve"},       {60, "exit"},          {61, "wait4"},
+        {62, "kill"},         {63, "uname"},         {72, "fcntl"},
+        {78, "getdents"},     {79, "getcwd"},        {80, "chdir"},
+        {82, "rename"},       {83, "mkdir"},         {84, "rmdir"},
+        {85, "creat"},        {86, "link"},          {87, "unlink"},
+        {88, "symlink"},      {89, "readlink"},      {90, "chmod"},
+        {91, "fchmod"},       {92, "chown"},         {101, "ptrace"},
+        {102, "getuid"},      {104, "getgid"},       {105, "setuid"},
+        {106, "setgid"},      {107, "geteuid"},      {108, "getegid"},
+        {110, "getppid"},     {137, "statfs"},       {157, "prctl"},
+        {158, "arch_prctl"},  {165, "mount"},        {166, "umount2"},
+        {169, "reboot"},      {186, "gettid"},       {200, "tkill"},
+        {202, "futex"},       {217, "getdents64"},   {231, "exit_group"},
+        {257, "openat"},      {258, "mkdirat"},      {259, "mknodat"},
+        {260, "fchownat"},    {263, "unlinkat"},     {265, "linkat"},
+        {266, "symlinkat"},   {267, "readlinkat"},   {268, "fchmodat"},
+        {269, "faccessat"},   {280, "utimensat"},    {288, "accept4"},
+        {292, "dup3"},        {299, "recvmmsg"},     {307, "sendmmsg"},
+        {310, "process_vm_readv"},                   {311, "process_vm_writev"},
+        {316, "renameat2"},   {318, "getrandom"},    {319, "memfd_create"},
+        {321, "bpf"},         {322, "execveat"},     {332, "statx"},
+        {435, "clone3"},      {437, "openat2"},      {439, "faccessat2"},
+    };
+
+    const auto it = kTable.find(number);
+    if (it != kTable.end())
+        return it->second;
+    return "sys_" + std::to_string(number);
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxSyscalls.hh
+++ b/src/linux/kernel/LinuxSyscalls.hh
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief x86_64 Linux syscall number → name lookup.
+ *
+ * A curated table of the common, version-stable x86_64 syscalls (the ones
+ * that matter for malware behaviour — file, network, process, exec). Unknown
+ * numbers fall back to `"sys_<nr>"`, matching the hybrid linux-syscalls-direct
+ * tracer's convention, so the runner's classifier (which strips the `sys_`
+ * prefix) handles either form.
+ *
+ * This is the naming foundation for `ivsyscallmon` on Linux. Argument
+ * decoding + per-syscall handler classes (the full win_syscall_generator
+ * analogue) come later; for completeness the table can be regenerated from a
+ * kernel's `arch/x86/entry/syscalls/syscall_64.tbl`.
+ */
+class LinuxSyscalls {
+  public:
+    /**
+     * @brief Name for an x86_64 syscall number (e.g. 257 -> "openat"), or
+     *        "sys_<nr>" if not in the curated table.
+     */
+    static std::string name(uint32_t number);
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxSyscallsArm64.cc
+++ b/src/linux/kernel/LinuxSyscallsArm64.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxSyscallsArm64.hh"
+
+#include <unordered_map>
+
+namespace introvirt {
+namespace linux_guest {
+
+std::string LinuxSyscallsArm64::name(uint32_t number) {
+    // Curated, version-stable AArch64 syscall numbers from the architecture's
+    // asm-generic table (include/uapi/asm-generic/unistd.h). Focused on the
+    // file / network / process / exec calls that matter for behavioural
+    // analysis. Note: arm64 has no bare open/fork/dup2/stat/access — the
+    // *at-suffixed forms are the only ones (openat, dup3, newfstatat,
+    // faccessat) — so those legacy names are deliberately absent.
+    static const std::unordered_map<uint32_t, const char*> kTable = {
+        {17, "getcwd"},        {23, "dup"},           {24, "dup3"},
+        {25, "fcntl"},         {29, "ioctl"},         {33, "mknodat"},
+        {34, "mkdirat"},       {35, "unlinkat"},      {36, "symlinkat"},
+        {37, "linkat"},        {38, "renameat"},      {39, "umount2"},
+        {40, "mount"},         {43, "statfs"},        {45, "truncate"},
+        {46, "ftruncate"},     {48, "faccessat"},     {49, "chdir"},
+        {51, "chroot"},        {52, "fchmod"},        {53, "fchmodat"},
+        {54, "fchownat"},      {55, "fchown"},        {56, "openat"},
+        {57, "close"},         {59, "pipe2"},         {61, "getdents64"},
+        {62, "lseek"},         {63, "read"},          {64, "write"},
+        {65, "readv"},         {66, "writev"},        {67, "pread64"},
+        {68, "pwrite64"},      {71, "sendfile"},      {72, "pselect6"},
+        {73, "ppoll"},         {78, "readlinkat"},    {79, "newfstatat"},
+        {80, "fstat"},         {82, "fsync"},         {90, "capget"},
+        {91, "capset"},        {93, "exit"},          {94, "exit_group"},
+        {96, "set_tid_address"}, {98, "futex"},       {101, "nanosleep"},
+        {117, "ptrace"},       {122, "sched_setaffinity"},
+        {124, "sched_yield"},  {129, "kill"},         {130, "tkill"},
+        {131, "tgkill"},       {134, "rt_sigaction"}, {135, "rt_sigprocmask"},
+        {139, "rt_sigreturn"}, {153, "times"},        {157, "setsid"},
+        {160, "uname"},        {165, "getrusage"},    {167, "prctl"},
+        {169, "gettimeofday"}, {172, "getpid"},       {173, "getppid"},
+        {174, "getuid"},       {175, "geteuid"},      {176, "getgid"},
+        {177, "getegid"},      {178, "gettid"},       {179, "sysinfo"},
+        {198, "socket"},       {199, "socketpair"},   {200, "bind"},
+        {201, "listen"},       {202, "accept"},       {203, "connect"},
+        {204, "getsockname"},  {205, "getpeername"},  {206, "sendto"},
+        {207, "recvfrom"},     {208, "setsockopt"},   {209, "getsockopt"},
+        {210, "shutdown"},     {211, "sendmsg"},      {212, "recvmsg"},
+        {214, "brk"},          {215, "munmap"},       {216, "mremap"},
+        {220, "clone"},        {221, "execve"},       {222, "mmap"},
+        {223, "fadvise64"},    {226, "mprotect"},     {227, "msync"},
+        {233, "madvise"},      {242, "accept4"},      {243, "recvmmsg"},
+        {260, "wait4"},        {261, "prlimit64"},    {269, "sendmmsg"},
+        {270, "process_vm_readv"},                    {271, "process_vm_writev"},
+        {272, "kcmp"},         {277, "seccomp"},      {278, "getrandom"},
+        {279, "memfd_create"}, {280, "bpf"},          {281, "execveat"},
+        {285, "copy_file_range"}, {286, "preadv2"},   {287, "pwritev2"},
+        {291, "statx"},        {424, "pidfd_send_signal"},
+        {434, "pidfd_open"},   {435, "clone3"},       {436, "close_range"},
+        {437, "openat2"},      {438, "pidfd_getfd"},  {439, "faccessat2"},
+        {440, "process_madvise"},
+    };
+
+    const auto it = kTable.find(number);
+    if (it != kTable.end())
+        return it->second;
+    return "sys_" + std::to_string(number);
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxSyscallsArm64.hh
+++ b/src/linux/kernel/LinuxSyscallsArm64.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief AArch64 (arm64) Linux syscall number → name lookup.
+ *
+ * arm64 does NOT share x86_64's syscall numbers: it uses the architecture's
+ * `asm-generic` table (`include/uapi/asm-generic/unistd.h`), so `read=63`,
+ * `openat=56` (there is no bare `open`), `execve=221`, `clone=220`,
+ * `socket=198`, `mmap=222`. This curated table covers the common,
+ * version-stable calls that matter for malware behaviour (file, network,
+ * process, exec); unknown numbers fall back to `"sys_<nr>"`, matching the
+ * x86_64 `LinuxSyscalls` convention so the runner's classifier handles either.
+ *
+ * This is the arch-neutral *first brick* of the arm64 port (see
+ * docs/introvirt-arm64.md): it is pure data with no architecture coupling, so
+ * it compiles and is testable today, ahead of the core arm64 backend. Phase 4
+ * (the arm64 Linux guest model) consumes it from the syscall decoder, exactly
+ * as the x86_64 path consumes `LinuxSyscalls`.
+ */
+class LinuxSyscallsArm64 {
+  public:
+    /**
+     * @brief Name for an AArch64 syscall number (e.g. 56 -> "openat"), or
+     *        "sys_<nr>" if not in the curated table.
+     */
+    static std::string name(uint32_t number);
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxTask.cc
+++ b/src/linux/kernel/LinuxTask.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxTask.hh"
+
+#include "linux/profile/LinuxProfileImpl.hh" // LinuxProfileException
+
+#include <introvirt/core/domain/Domain.hh>
+#include <introvirt/core/memory/guest_ptr.hh>
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+#include <introvirt/linux/profile/LinuxProfile.hh>
+
+#include <cstring>
+
+namespace introvirt {
+namespace linux_guest {
+
+namespace {
+template <typename T>
+T read_scalar(const Domain& domain, uint64_t address, uint64_t page_directory) {
+    guest_ptr<T> ptr(domain, address, page_directory);
+    return *ptr;
+}
+} // namespace
+
+LinuxTask::LinuxTask(const LinuxKernel& kernel, const Domain& domain, uint64_t page_directory,
+                     uint64_t task_address)
+    : kernel_(kernel), domain_(domain), page_directory_(page_directory),
+      task_address_(task_address) {}
+
+int64_t LinuxTask::offset(const char* member) const {
+    const auto off = kernel_.profile().member_offset("task_struct", member);
+    if (!off)
+        throw LinuxProfileException(std::string("task_struct.") + member +
+                                    " missing from Linux profile");
+    return *off;
+}
+
+int32_t LinuxTask::pid() const {
+    return read_scalar<int32_t>(domain_, task_address_ + offset("pid"), page_directory_);
+}
+
+int32_t LinuxTask::tgid() const {
+    return read_scalar<int32_t>(domain_, task_address_ + offset("tgid"), page_directory_);
+}
+
+uint64_t LinuxTask::mm() const {
+    return read_scalar<uint64_t>(domain_, task_address_ + offset("mm"), page_directory_);
+}
+
+std::string LinuxTask::comm() const {
+    // task_struct.comm is char[TASK_COMM_LEN] (16), NUL-padded.
+    static constexpr size_t kCommLen = 16;
+    guest_ptr<char[]> ptr(domain_, task_address_ + offset("comm"), page_directory_, kCommLen);
+    const char* data = ptr.get();
+    return std::string(data, ::strnlen(data, kCommLen));
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/kernel/LinuxTask.hh
+++ b/src/linux/kernel/LinuxTask.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace introvirt {
+
+class Domain;
+
+namespace linux_guest {
+
+class LinuxKernel;
+
+/**
+ * @brief Reads one `task_struct` from guest memory via the profile offsets.
+ *
+ * The reusable primitive the Linux process model is built on: given a
+ * task_struct's kernel virtual address it exposes pid/tgid/comm/mm. The
+ * process list (walking `init_task.tasks`) and the per-CPU current-task
+ * resolution both build on this (Phase 2 in docs/introvirt-linux-port.md).
+ *
+ * Fields are read lazily on access (no caching) so a LinuxTask is cheap to
+ * construct while iterating a task list.
+ */
+class LinuxTask {
+  public:
+    /**
+     * @param kernel          resolves the task_struct member offsets
+     * @param domain          guest to read from
+     * @param page_directory  CR3 / pgd used to translate the reads
+     * @param task_address    kernel virtual address of the task_struct
+     */
+    LinuxTask(const LinuxKernel& kernel, const Domain& domain, uint64_t page_directory,
+              uint64_t task_address);
+
+    uint64_t address() const { return task_address_; }
+
+    int32_t pid() const;   ///< task_struct.pid  (thread id, Linux sense)
+    int32_t tgid() const;  ///< task_struct.tgid (process id)
+    std::string comm() const; ///< task_struct.comm (<=16 bytes, NUL-padded)
+    uint64_t mm() const;   ///< task_struct.mm pointer (0 for kernel threads)
+
+  private:
+    int64_t offset(const char* member) const;
+
+    const LinuxKernel& kernel_;
+    const Domain& domain_;
+    uint64_t page_directory_;
+    uint64_t task_address_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/profile/LinuxProfile.cc
+++ b/src/linux/profile/LinuxProfile.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxProfileImpl.hh"
+
+#include <introvirt/linux/profile/LinuxProfile.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+
+namespace introvirt {
+namespace linux_guest {
+
+std::unique_ptr<LinuxProfile> LinuxProfile::load(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in)
+        throw LinuxProfileException("LinuxProfile: cannot open " + path);
+    std::ostringstream buf;
+    buf << in.rdbuf();
+    return std::make_unique<LinuxProfileImpl>(buf.str());
+}
+
+std::unique_ptr<LinuxProfile> LinuxProfile::load_for_release(const std::string& release,
+                                                             const std::string& arch) {
+    // Resolution order mirrors the Windows NtKernel::profile_path() convention:
+    //   1. $INTROVIRT_PROFILE_DIR (explicit override)
+    //   2. $HOME/.introvirt/profiles
+    std::string dir;
+    if (const char* env = std::getenv("INTROVIRT_PROFILE_DIR")) {
+        dir = env;
+    } else if (const char* home = std::getenv("HOME")) {
+        dir = std::string(home) + "/.introvirt/profiles";
+    } else {
+        return nullptr;
+    }
+
+    const std::string path = dir + "/linux-" + release + "-" + arch + ".json";
+
+    // Missing profile is not an error here (the caller decides) — only a
+    // present-but-broken profile throws, via load().
+    std::ifstream probe(path);
+    if (!probe)
+        return nullptr;
+    return load(path);
+}
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/profile/LinuxProfileImpl.cc
+++ b/src/linux/profile/LinuxProfileImpl.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "LinuxProfileImpl.hh"
+
+#include <introvirt/util/json/json.hh>
+
+#include <sstream>
+
+namespace introvirt {
+namespace linux_guest {
+
+// Must match tools/linux/generate_isf.py PROFILE_FORMAT.
+static constexpr const char* kExpectedFormat = "sectepe-linux-isf/1";
+
+LinuxProfileImpl::LinuxProfileImpl(const std::string& json_text) {
+    Json::CharReaderBuilder builder;
+    Json::Value root;
+    Json::String errs;
+    std::istringstream ss(json_text);
+    if (!Json::parseFromStream(builder, ss, &root, &errs))
+        throw LinuxProfileException("LinuxProfile: JSON parse error: " + errs);
+
+    const std::string format = root.get("format", "").asString();
+    if (format != kExpectedFormat)
+        throw LinuxProfileException("LinuxProfile: unexpected format '" + format +
+                                    "' (expected " + kExpectedFormat + ")");
+
+    arch_ = root["metadata"].get("arch", "x86_64").asString();
+
+    const Json::Value& symbols = root["symbols"];
+    for (const auto& name : symbols.getMemberNames())
+        symbols_[name] = symbols[name].asUInt64();
+
+    const Json::Value& types = root["types"];
+    for (const auto& type : types.getMemberNames()) {
+        const Json::Value& members = types[type];
+        auto& member_map = types_[type];
+        for (const auto& member : members.getMemberNames())
+            member_map[member] = members[member].asInt64();
+    }
+
+    const Json::Value& sizes = root["sizes"];
+    for (const auto& type : sizes.getMemberNames())
+        sizes_[type] = sizes[type].asUInt64();
+
+    if (symbols_.empty())
+        throw LinuxProfileException("LinuxProfile: no symbols in profile");
+}
+
+std::optional<uint64_t> LinuxProfileImpl::symbol(const std::string& name) const {
+    auto it = symbols_.find(name);
+    if (it == symbols_.end())
+        return std::nullopt;
+    return it->second;
+}
+
+std::optional<int64_t> LinuxProfileImpl::member_offset(const std::string& type,
+                                                       const std::string& member) const {
+    auto type_it = types_.find(type);
+    if (type_it == types_.end())
+        return std::nullopt;
+    auto member_it = type_it->second.find(member);
+    if (member_it == type_it->second.end())
+        return std::nullopt;
+    return member_it->second;
+}
+
+std::optional<uint64_t> LinuxProfileImpl::type_size(const std::string& type) const {
+    auto it = sizes_.find(type);
+    if (it == sizes_.end())
+        return std::nullopt;
+    return it->second;
+}
+
+const std::string& LinuxProfileImpl::arch() const { return arch_; }
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/linux/profile/LinuxProfileImpl.hh
+++ b/src/linux/profile/LinuxProfileImpl.hh
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 SecTepe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include <introvirt/core/exception/TraceableException.hh>
+#include <introvirt/linux/profile/LinuxProfile.hh>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace introvirt {
+namespace linux_guest {
+
+/**
+ * @brief Thrown when a Linux profile cannot be loaded or is malformed.
+ *
+ * Context-free (no Vcpu/Domain), unlike GuestDetectionException — the
+ * profile is loaded from the host filesystem before any guest is attached.
+ */
+class LinuxProfileException : public TraceableException {
+  public:
+    explicit LinuxProfileException(const std::string& msg) : TraceableException(msg) {}
+};
+
+/**
+ * @brief Concrete LinuxProfile backed by a parsed `sectepe-linux-isf/1` JSON.
+ *
+ * The maps are populated once at construction from the JSON text; lookups
+ * are then O(1). See tools/linux/generate_isf.py for the emitter and
+ * include/introvirt/linux/profile/LinuxProfile.hh for the interface.
+ */
+class LinuxProfileImpl final : public LinuxProfile {
+  public:
+    std::optional<uint64_t> symbol(const std::string& name) const override;
+    std::optional<int64_t> member_offset(const std::string& type,
+                                         const std::string& member) const override;
+    std::optional<uint64_t> type_size(const std::string& type) const override;
+    const std::string& arch() const override;
+
+    /**
+     * @brief Parse a `sectepe-linux-isf/1` profile from its JSON text.
+     * @throws LinuxProfileException on parse error or unexpected format.
+     */
+    explicit LinuxProfileImpl(const std::string& json_text);
+
+  private:
+    std::string arch_;
+    std::unordered_map<std::string, uint64_t> symbols_;
+    std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> types_;
+    std::unordered_map<std::string, uint64_t> sizes_;
+};
+
+} // namespace linux_guest
+} // namespace introvirt

--- a/src/windows/event/WindowsEventTaskInformation.cc
+++ b/src/windows/event/WindowsEventTaskInformation.cc
@@ -15,23 +15,36 @@
  */
 #include <introvirt/windows/event/WindowsEventTaskInformation.hh>
 
+#include <introvirt/core/exception/TraceableException.hh>
 #include <introvirt/windows/kernel/nt/types/KPCR.hh>
 
 namespace introvirt {
 namespace windows {
 
-uint64_t WindowsEventTaskInformation::pid() const { return kpcr_.pid(); }
+// Return the values SNAPSHOTTED at construction (see the header); re-reading
+// kpcr_ here would race the shared per-vcpu KPCR -> stale-pointer SIGSEGV.
+uint64_t WindowsEventTaskInformation::pid() const { return pid_; }
 
-uint64_t WindowsEventTaskInformation::tid() const { return kpcr_.tid(); }
+uint64_t WindowsEventTaskInformation::tid() const { return tid_; }
 
-std::string WindowsEventTaskInformation::process_name() const { return kpcr_.process_name(); }
+std::string WindowsEventTaskInformation::process_name() const { return process_name_; }
 
 nt::KPCR& WindowsEventTaskInformation::pcr() { return kpcr_; }
 
 const nt::KPCR& WindowsEventTaskInformation::pcr() const { return kpcr_; }
 
 WindowsEventTaskInformation::WindowsEventTaskInformation(nt::KPCR& kpcr) : kpcr_(kpcr) {
+    // Built by the poller right after in_event_=true, so registers/KPCR are valid
+    // here. Resolve the current thread once and snapshot the ids so later
+    // accessors never re-read the shared, racy kpcr_.
     kpcr_.reset();
+    try {
+        pid_ = kpcr_.pid();
+        tid_ = kpcr_.tid();
+        process_name_ = kpcr_.process_name();
+    } catch (const TraceableException&) {
+        // degraded KPCR (KPTI non-canonical thread ptr) -> leave defaults
+    }
 }
 
 WindowsEventTaskInformation::~WindowsEventTaskInformation() = default;

--- a/src/windows/injection/syscall.hh
+++ b/src/windows/injection/syscall.hh
@@ -41,6 +41,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <optional>
 
 namespace introvirt {
@@ -70,10 +71,66 @@ class SystemCallInjector final {
         const auto original_ideal_processor = thread.IdealProcessor();
         const auto original_user_ideal_processor = thread.UserIdealProcessor();
 
-        thread.Affinity(desired_affinity);
-        thread.UserAffinity(desired_affinity);
-        thread.IdealProcessor(event_.vcpu().id());
-        thread.UserIdealProcessor(event_.vcpu().id());
+        // SECTEPE: the hard-affinity pin (writing KTHREAD.Affinity /
+        // KTHREAD.UserAffinity to a single-vcpu mask in live guest memory) is
+        // what deadlocks a heavy, blocking, cross-thread syscall such as
+        // NtCreateUserProcess on Win11.
+        //
+        // Why the pin hangs the heavy syscall but not a trivial one:
+        //   * start_injection() does NOT pause the other vcpus for a
+        //     FAST_SYSCALL injection (only INT3/MEM_ACCESS breakpoint
+        //     injections pause peers — see DomainImpl::start_injection). So
+        //     while the hijacked thread runs the injected syscall on this vcpu,
+        //     the other vcpu(s) keep executing guest code, including the kernel
+        //     scheduler.
+        //   * NtDeleteFile (and the other trivial calls) complete entirely
+        //     inside the syscall with no reschedule / no cross-processor wait,
+        //     so a bogus single-cpu affinity mask is never consulted before the
+        //     call returns: it SYSRETs fine.
+        //   * NtCreateUserProcess is long and blocking: it waits on the
+        //     PspCreateThread/section/IO paths, takes resources, and crucially
+        //     touches per-processor scheduler state and may need to be
+        //     rescheduled / have work run on another processor. With the hard
+        //     KTHREAD.Affinity clamped to exactly this one vcpu, the guest
+        //     scheduler can no longer migrate or wake the thread the way the
+        //     create path expects; the thread is left blocked in the kernel and
+        //     never SYSRETs (INJ=11 / RET=10) -> hang / -T timeout. The injector
+        //     is then stuck in suspend() waiting for a FAST_SYSCALL_RET that the
+        //     guest will never produce.
+        //   * On Win10 19045 the same clamp happens to be tolerated by that
+        //     build's create/scheduler path, so Win10 works WITH the pin and we
+        //     must NOT regress it.
+        //
+        // The differentiator is purely the scheduler clamp interacting with the
+        // Win11 heavy-create path, NOT the byte layout of KTHREAD.Affinity: that
+        // field is a KAFFINITY_EX structure on both Win10 and Win11 x64 and the
+        // 8-byte get()/set() round-trips it identically on both, so it cannot
+        // explain why only Win11 hangs. (We still capture the original 8 bytes
+        // and write the exact same value back on restore on every OS, so no new
+        // corruption is introduced regardless.)
+        //
+        // Fix: branch on the build number. Pre-22000 (Win10 and earlier) keeps
+        // the proven hard-affinity pin so the working path is unchanged.
+        // 22000+ (Win11) skips the hard Affinity/UserAffinity clamp and only
+        // sets the *soft* IdealProcessor / UserIdealProcessor scheduling hint
+        // (advisory: the scheduler prefers this cpu but is still free to migrate
+        // / wake the thread, so the heavy syscall can complete and SYSRET).
+        const uint16_t build_number = guest_.kernel().NtBuildNumber();
+        const bool win11_or_newer = (build_number >= 22000);
+
+        if (win11_or_newer) {
+            // Win11: advisory soft hint only, no hard Affinity/UserAffinity
+            // clamp, so the guest scheduler can still migrate/wake the thread
+            // and the heavy NtCreateUserProcess can complete and SYSRET.
+            thread.IdealProcessor(event_.vcpu().id());
+            thread.UserIdealProcessor(event_.vcpu().id());
+        } else {
+            // Win10 and earlier: keep the original, proven hard pin.
+            thread.Affinity(desired_affinity);
+            thread.UserAffinity(desired_affinity);
+            thread.IdealProcessor(event_.vcpu().id());
+            thread.UserIdealProcessor(event_.vcpu().id());
+        }
 
         // Save the original LastStatusValue so we can restore it later
         auto* teb = thread.Teb();
@@ -89,12 +146,70 @@ class SystemCallInjector final {
         try {
             // Wait for the return event
             vcpu.syscall_injection_start();
-            return_event = event_.impl().suspend([](const introvirt::Event& event) {
-                if (event.type() == EventType::EVENT_FAST_SYSCALL_RET) {
-                    return WakeAction::ACCEPT;
-                }
-                return WakeAction::PASS;
-            });
+
+            // SECTEPE: return-RIP-aware wake matching.
+            //
+            // On Win11 a >4-argument syscall (e.g. NtCreateUserProcess) whose
+            // stack is not fully paged in triggers verify_stack_present(), which
+            // injects a NESTED NtDeleteFile syscall to fault the stack in. The
+            // nesting is SYNCHRONOUS on one worker thread: the inner NtDeleteFile
+            // injector runs entirely inside the outer call's begin_syscall() ->
+            // verify_stack_present(), i.e. the inner ctor + inner call() +
+            // inner suspend()/wake() all complete BEFORE the outer ever reaches
+            // this suspend(). Both injectors obtain the SAME Event via
+            // ThreadLocalEvent::get(), so they share one EventImplTpl
+            // (check_wakeup_/cv_) and, for the pure nested case, the per-thread
+            // suspended_events_ multimap holds exactly ONE entry at each return.
+            //
+            // The hazard the generic "any FAST_SYSCALL_RET => ACCEPT" lambda
+            // caused: that single shared waiter accepts the FIRST FAST_SYSCALL_RET
+            // seen for the thread, even a foreign/early one. The inner waiter
+            // could consume the wrong return (or, when two different worker
+            // threads inject on the same guest KTHREAD and the map genuinely
+            // holds two entries for the tid, the outer waiter could swallow the
+            // inner's return). Either way verify_stack_present() never returns
+            // and the session deadlocks / -T times out.
+            //
+            // Fix: each injection only accepts the return whose userland return
+            // RIP equals the return address captured for ITS OWN injection point.
+            // For SYSCALL the hardware leaves the return address in RCX at kernel
+            // entry (captured in begin_syscall, after inject_syscall()). For
+            // SYSENTER the saved userland rip is written to the new stack frame
+            // (captured in begin_sysenter). On the matching SYSRET/SYSEXIT the
+            // guest is back at that userland address, so event.registers().rip()
+            // equals expected_return_rip_. A return that is not for THIS injection
+            // PASSes (EventImplTpl::wake only moves the event on ACCEPT, so the
+            // event is left intact for the filter_event loop / a later waiter).
+            // This is the same proven shape as the rsp-based hook_return
+            // correlation in DomainImpl::filter_event. Correctness does NOT depend
+            // on the unordered_multimap's equal-key iteration order.
+            //
+            // Defensive fallback: if we somehow failed to capture an expected RIP
+            // (expected_return_rip_ is unset), fall back to the original generic
+            // behaviour so a single, non-nested injection still wakes.
+            const std::optional<uint64_t> expected_return_rip = expected_return_rip_;
+            return_event =
+                event_.impl().suspend([expected_return_rip](const introvirt::Event& event) {
+                    if (event.type() == EventType::EVENT_FAST_SYSCALL_RET) {
+                        if (!expected_return_rip ||
+                            event.vcpu().registers().rip() == *expected_return_rip) {
+                            return WakeAction::ACCEPT;
+                        }
+                        // A FAST_SYSCALL_RET for this thread but a different
+                        // injection point (e.g. the inner NtDeleteFile return
+                        // arriving while a different waiter is offered the event
+                        // first, or the kernel running other work in the context
+                        // of the suspended thread). Let it PASS so the loop
+                        // offers it to the matching suspended injection. Mirrors
+                        // the hook_return rsp-mismatch TRACE in DomainImpl.
+                        LOG4CXX_TRACE(syscall_injector_logger,
+                                      "Incorrect return rip: 0x"
+                                          << std::hex << event.vcpu().registers().rip()
+                                          << " Wanted 0x" << *expected_return_rip);
+                        return WakeAction::PASS;
+                    }
+                    return WakeAction::PASS;
+                });
             event_.impl().injection_performed(true);
 
         } catch (...) {
@@ -294,6 +409,11 @@ class SystemCallInjector final {
 
         // Write the return address on our new stack
         *guest_ptr<uint32_t>(vcpu, regs.rdx()) = rip;
+
+        // SECTEPE: this is the userland address SYSEXIT/SYSRET will return to;
+        // the matching FAST_SYSCALL_RET for this injection lands here. Used to
+        // disambiguate nested injections on the same thread in call().
+        expected_return_rip_ = rip;
     }
 
     void begin_syscall(unsigned int arg_count, unsigned int additional_stack) {
@@ -322,6 +442,15 @@ class SystemCallInjector final {
         // For example, if we do this in a CR3 write event the guest will die.
         event_.vcpu().inject_syscall();
 
+        // SECTEPE: SYSCALL stashes the userland return address (the instruction
+        // after SYSCALL) in RCX, and the KVM layer reloads the registers after
+        // injecting, so RCX is valid here. SYSRET restores RIP from RCX, so the
+        // matching FAST_SYSCALL_RET for this injection returns to this address.
+        // This is captured per-injector (each nested NtDeleteFile from
+        // verify_stack_present is a distinct SystemCallInjector with its own
+        // member) so returns are routed to the correct waiter in call().
+        expected_return_rip_ = regs.rcx();
+
         regs.rsp(stack_bottom);
 
         rsp_ = regs.rsp();
@@ -333,6 +462,13 @@ class SystemCallInjector final {
     WindowsGuest& guest_;
     std::optional<x86::Segment> original_cs_;
     uint64_t rsp_;
+
+    // SECTEPE: userland return RIP for THIS injection's call site, used to
+    // route the matching FAST_SYSCALL_RET to the correct waiter when nested
+    // injections share a thread_id (see call()). Captured in
+    // begin_syscall()/begin_sysenter() right after the SYSCALL/SYSENTER is
+    // forced into the guest.
+    std::optional<uint64_t> expected_return_rip_;
 };
 
 } // namespace inject

--- a/src/windows/injection/syscall.hh
+++ b/src/windows/injection/syscall.hh
@@ -19,6 +19,7 @@
 #include "core/domain/VcpuImpl.hh"
 #include "core/event/EventImpl.hh"
 #include "core/injection/RegisterGuard.hh"
+#include "core/injection/VcpuPauseGuard.hh"
 #include "windows/WindowsGuestImpl.hh"
 
 #include <introvirt/core/breakpoint/Breakpoint.hh>
@@ -188,6 +189,10 @@ class SystemCallInjector final {
             // (expected_return_rip_ is unset), fall back to the original generic
             // behaviour so a single, non-nested injection still wakes.
             const std::optional<uint64_t> expected_return_rip = expected_return_rip_;
+            // Release our pause so the injected syscall actually RUNS on the guest
+            // during the suspend wait (suspend completes the event -> the vcpu
+            // executes the call). Re-paused below once its return is in hand.
+            pause_guard_.reset();
             return_event =
                 event_.impl().suspend([expected_return_rip](const introvirt::Event& event) {
                     if (event.type() == EventType::EVENT_FAST_SYSCALL_RET) {
@@ -210,10 +215,20 @@ class SystemCallInjector final {
                     }
                     return WakeAction::PASS;
                 });
+            // The syscall has returned (we hold its return event). Re-pause for
+            // the cleanup + RAII teardown register accesses (end_injection,
+            // TEB/affinity restores, ~RegisterGuard) so they don't race EBUSY.
+            pause_guard_.emplace(event_.vcpu());
+            refresh_registers_after_repause();
             event_.impl().injection_performed(true);
 
         } catch (...) {
             // Duplicated because c++ doesn't have 'finally'
+            // Ensure the cleanup below runs on a paused vcpu even if we threw while
+            // the pause was released (during suspend / verify_stack_present).
+            if (!pause_guard_)
+                pause_guard_.emplace(event_.vcpu());
+            refresh_registers_after_repause();
             vcpu.syscall_injection_end();
             static_cast<DomainImpl&>(event_.domain()).end_injection(event_);
 
@@ -274,6 +289,13 @@ class SystemCallInjector final {
         introvirt_assert(event.os_type() == OS::Windows, "");
 
         auto& vcpu = event_.vcpu();
+        // SECTEPE: pause this vcpu for the injector's register-access regions.
+        // For a SEQUENTIAL injection the vcpu is running again (the previous
+        // injection released its pause), so without this the very first
+        // registers() read below throws EBUSY -> the injection (e.g. the
+        // NtResumeThread that actually starts the created process) is aborted.
+        // Released only around verify_stack_present + suspend (the executions).
+        pause_guard_.emplace(event_.vcpu());
         auto& regs = vcpu.registers();
 
         // Set the VCPU to the correct call number
@@ -368,6 +390,9 @@ class SystemCallInjector final {
         // Move the stack backwards enough to hold our arguments plus the return address
         const unsigned int stack_offset = (arg_count + 2) * sizeof(uint32_t);
 
+        // Nested verify_stack_present injections must run on the guest; drop our
+        // pause around them, then re-pause + refresh the register cache.
+        pause_guard_.reset();
         switch (event_.type()) {
         case EventType::EVENT_FAST_SYSCALL:
             verify_stack_present(regs.rdx() - stack_offset - additional_stack, regs.rdx());
@@ -377,6 +402,8 @@ class SystemCallInjector final {
             verify_stack_present(regs.rsp() - stack_offset - additional_stack, regs.rsp());
             break;
         }
+        pause_guard_.emplace(event_.vcpu());
+        refresh_registers_after_repause();
 
         // Force a SYSENTER in the guest
         // This works even if we're already in an EVENT_FAST_SYSCALL.
@@ -433,8 +460,14 @@ class SystemCallInjector final {
         const uint64_t stack_bottom = regs.rsp() - (arg_count + 2) * sizeof(uint64_t);
 
         // Prevents a recursive loop with NtDeleteFile to page in the stack
-        if (arg_count > 4 || additional_stack > 0)
+        if (arg_count > 4 || additional_stack > 0) {
+            // The nested NtDeleteFile injections must RUN on the guest, so drop
+            // our pause around them, then re-pause and refresh the register cache.
+            pause_guard_.reset();
             verify_stack_present(stack_bottom - additional_stack, regs.rsp());
+            pause_guard_.emplace(event_.vcpu());
+            refresh_registers_after_repause();
+        }
 
         // This works even if we're already in an EVENT_FAST_SYSCALL.
         // In KVM, since the RIP changes, it won't happen twice.
@@ -456,7 +489,19 @@ class SystemCallInjector final {
         rsp_ = regs.rsp();
     }
 
+    // Refresh the cached register state after the vcpu has been re-paused
+    // following a region where it ran (verify_stack_present / suspend). The
+    // re-pause does not reload registers unless we were in an event, so trigger
+    // a read here; `regs` references the same cache object so it sees the update.
+    void refresh_registers_after_repause() {
+        if (pause_guard_)
+            (void)event_.vcpu().registers();
+    }
+
   private:
+    // Declared BEFORE guard_ so it is destroyed AFTER ~RegisterGuard (whose dtor
+    // restores registers and must run on the still-paused vcpu).
+    std::optional<introvirt::inject::VcpuPauseGuard> pause_guard_;
     std::optional<introvirt::inject::RegisterGuard> guard_;
     WindowsEvent& event_;
     WindowsGuest& guest_;

--- a/src/windows/kernel/nt/types/KPCR_IMPL.cc
+++ b/src/windows/kernel/nt/types/KPCR_IMPL.cc
@@ -27,6 +27,7 @@
 #include <introvirt/core/arch/arch.hh>
 #include <introvirt/core/domain/Vcpu.hh>
 #include <introvirt/core/exception/GuestDetectionException.hh>
+#include <introvirt/core/exception/TraceableException.hh>
 
 #include <log4cxx/logger.h>
 
@@ -109,10 +110,93 @@ void KPCR_IMPL<PtrType>::reset() {
     if (!dtb)
         dtb = vcpu_.registers().cr3();
 
-    const guest_ptr<void> pcurrent_thread(vcpu_.domain(), current_thread_address(), dtb);
+    /*
+     * Building the current THREAD here can fail when this VCPU is observed mid-context-switch, or is
+     * in user mode under KPTI with no KernelDirectoryTableBase available (so dtb falls back to the
+     * user CR3 above). In those cases current_thread_address() resolves through the wrong page
+     * tables and yields a garbage/non-canonical pointer, and the subsequent THREAD/OBJECT_HEADER
+     * read throws (e.g. IncorrectTypeException "Type index out of range", or
+     * VirtualAddressNotPresentException for a non-canonical VA).
+     *
+     * This reset() runs on the VCPU poller thread while building an event (via
+     * WindowsEventTaskInformation -> WindowsEventImpl), where the surrounding loop only catches
+     * EventPollException -- so any throw here would escape and std::terminate the process. This is
+     * easy to trigger while another VCPU is performing syscall injection (NtCreateUserProcess),
+     * which churns context switches on the other VCPUs.
+     *
+     * Prevent the bad read at the source: KPRCB.CurrentThread always holds a canonical kernel-half
+     * pointer (>= 0xFFFF800000000000) for any real thread. A value outside that range is a torn /
+     * stale read (e.g. the non-canonical 0x8A.. variant, or a user-half value seen mid-switch), so
+     * reject it up front -- this is cheaper and safer than walking the page tables and constructing
+     * a THREAD/OBJECT_HEADER only to throw deep inside. PageDirectory::translate() masks the top 16
+     * bits off the VA (va_mask_), so a non-canonical pointer would otherwise silently alias a
+     * present-but-wrong page and mis-decode an object header rather than failing cleanly.
+     *
+     * Either way (rejected here, or a residual canonical-but-stale pointer that still throws in the
+     * try below) we degrade to the idle() case above: current_thread_ == nullptr is already a
+     * legitimate, supported state. Downstream KPCR_IMPL::pid()/tid()/process_name() are already
+     * null-safe; the only callers that throw on a null current thread (KPCR::CurrentThread() ->
+     * IdleThreadException) run later in the event_deliverer / callback path, which catches
+     * TraceableException per-event. We clear os_data as well so the stale PROCESS pointer from a
+     * previous event is not reused; all os_data consumers already null-check it.
+     */
+    if constexpr (std::is_same_v<uint64_t, PtrType>) {
+        // x86_64 canonical kernel half. 32-bit kernels use the whole 4 GiB range for kernel
+        // pointers, so this guard only applies to long mode.
+        static constexpr uint64_t kKernelHalf = 0xFFFF800000000000ULL;
+        if (unlikely(current_thread_address() < kKernelHalf)) {
+            LOG4CXX_DEBUG(logger, "Vcpu " << vcpu_.id()
+                                          << " current thread pointer not in kernel half ("
+                                          << n2hexstr(current_thread_address())
+                                          << "), treating as no current thread");
+            current_thread_ = nullptr;
+            vcpu_.os_data(nullptr);
+            return;
+        }
+    }
 
-    current_thread_ = kernel_.thread(pcurrent_thread);
-    vcpu_.os_data(&current_thread_->Process());
+    /*
+     * Count consecutive residual read failures so a genuine, non-transient
+     * regression in THREAD/object parsing stays visible (the FIRST failure of a
+     * streak is logged at WARN, even when DEBUG is disabled), while a stuck vcpu
+     * does not spam a WARN per event. reset() is only ever called from the
+     * event-construction path on a vcpu's own poller thread, so this thread_local
+     * counter is effectively per-vcpu and needs no synchronization. It is reset to
+     * zero whenever the current thread reads cleanly.
+     */
+    thread_local uint64_t reset_failures = 0;
+
+    try {
+        const guest_ptr<void> pcurrent_thread(vcpu_.domain(), current_thread_address(), dtb);
+
+        current_thread_ = kernel_.thread(pcurrent_thread);
+        vcpu_.os_data(&current_thread_->Process());
+
+        // Clean read: clear any failure streak so the next bad read is logged
+        // loudly again.
+        reset_failures = 0;
+    } catch (const TraceableException& ex) {
+        /*
+         * Residual canonical-but-stale pointer that still failed to parse a
+         * THREAD/OBJECT_HEADER. Degrade to the idle() state (current_thread_ ==
+         * nullptr) and clear os_data so the previous event's PROCESS pointer is
+         * not reused.
+         */
+        if (unlikely(reset_failures++ % 1000 == 0)) {
+            LOG4CXX_WARN(logger, "Vcpu " << vcpu_.id()
+                                         << " failed to read current thread during KPCR reset "
+                                            "(failure #"
+                                         << reset_failures
+                                         << "), treating as no current thread: " << ex.what());
+        } else {
+            LOG4CXX_DEBUG(logger, "Vcpu " << vcpu_.id()
+                                          << " failed to read current thread during KPCR reset, "
+                                             "treating as no current thread: "
+                                          << ex.what());
+        }
+        current_thread_ = nullptr;
+        vcpu_.os_data(nullptr);
+    }
 }
 
 template <typename PtrType>

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -29,6 +29,7 @@ FUNCTION(ADD_TOOL_EXECUTABLE EXE_NAME )
 
 ENDFUNCTION()
 
+ADD_TOOL_EXECUTABLE(ivbugcheck "ivbugcheck.cc")
 ADD_TOOL_EXECUTABLE(ivcallmon "ivcallmon.cc")
 ADD_TOOL_EXECUTABLE(ivcr3mon "ivcr3mon.cc")
 ADD_TOOL_EXECUTABLE(ivexec "ivexec.cc")

--- a/tools/ivbugcheck.cc
+++ b/tools/ivbugcheck.cc
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 Assured Information Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @example ivbugcheck.cc
+ *
+ * Reads the kernel's KiBugCheckData array from a (typically bugchecked) Windows
+ * guest and decodes the stop code + 4 parameters. For IRQL_NOT_LESS_OR_EQUAL
+ * (0x0A) it interprets the params and resolves the faulting address and
+ * referenced address to loaded kernel modules.
+ */
+
+#include <introvirt/introvirt.hh>
+
+#include <boost/program_options.hpp>
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+using namespace introvirt;
+using namespace introvirt::windows;
+using namespace introvirt::windows::nt;
+
+namespace po = boost::program_options;
+
+static std::string resolve_module(const WindowsGuest& guest, uint64_t addr) {
+    if (!addr)
+        return "(null)";
+    try {
+        for (const auto& mod : guest.kernel().PsLoadedModuleList()) {
+            const uint64_t base = mod->DllBase();
+            const uint64_t end = base + mod->SizeOfImage();
+            if (addr >= base && addr < end) {
+                std::ostringstream os;
+                os << mod->BaseDllName() << "+0x" << std::hex << (addr - base);
+                return os.str();
+            }
+        }
+    } catch (...) {
+    }
+    return "(not in a loaded module)";
+}
+
+int main(int argc, char** argv) {
+    std::string domain_name;
+
+    po::options_description desc("Options");
+    // clang-format off
+    desc.add_options()
+      ("domain,D", po::value<std::string>(&domain_name)->required(), "The domain to attach to")
+      ("help", "Display program help");
+    // clang-format on
+
+    po::variables_map vm;
+    try {
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+        if (vm.count("help")) {
+            std::cout << desc << '\n';
+            return 0;
+        }
+        po::notify(vm);
+    } catch (po::error& e) {
+        std::cerr << "ERROR: " << e.what() << "\n\n" << desc << std::endl;
+        return 1;
+    }
+
+    auto hypervisor = Hypervisor::instance();
+    auto domain = hypervisor->attach_domain(domain_name);
+
+    if (!domain->detect_guest()) {
+        std::cerr << "Failed to detect guest operating system\n";
+        return 1;
+    }
+
+    domain->pause();
+
+    auto* guest_base = domain->guest();
+    if (guest_base->os() != OS::Windows) {
+        std::cerr << "Not a Windows guest\n";
+        domain->resume();
+        return 1;
+    }
+    auto& guest = static_cast<WindowsGuest&>(*guest_base);
+
+    int rc = 0;
+    try {
+        const auto& kernel = guest.kernel();
+        const guest_ptr<void> sym = kernel.symbol("KiBugCheckData");
+        const uint64_t addr = sym.address();
+
+        // Rebind the void symbol pointer to a uint64_t[5] (the KiBugCheckData array).
+        guest_ptr<uint64_t[]> data(sym, 5);
+        const uint64_t code = data[0];
+        const uint64_t p1 = data[1];
+        const uint64_t p2 = data[2];
+        const uint64_t p3 = data[3];
+        const uint64_t p4 = data[4];
+
+        std::cout << std::hex << std::showbase;
+        std::cout << "KiBugCheckData @ " << addr << "\n";
+        std::cout << "  BugCheckCode = " << code << "\n";
+        std::cout << "  Param1       = " << p1 << "\n";
+        std::cout << "  Param2       = " << p2 << "\n";
+        std::cout << "  Param3       = " << p3 << "\n";
+        std::cout << "  Param4       = " << p4 << "\n";
+
+        if (code == 0) {
+            std::cout << "\n(no bugcheck recorded; guest has not crashed)\n";
+        } else if (code == 0x0A) {
+            std::cout << "\nIRQL_NOT_LESS_OR_EQUAL (0x0A):\n";
+            std::cout << "  Referenced address = " << p1 << "  -> "
+                      << resolve_module(guest, p1) << "\n";
+            std::cout << "  IRQL               = " << p2 << "\n";
+            std::cout << "  Access             = " << (p3 ? "write" : "read") << " ("
+                      << p3 << ")\n";
+            std::cout << "  Faulting RIP       = " << p4 << "  -> "
+                      << resolve_module(guest, p4) << "\n";
+        } else {
+            std::cout << "\nFaulting RIP guess (Param4) -> " << resolve_module(guest, p4) << "\n";
+        }
+        std::cout << std::dec << std::noshowbase;
+    } catch (std::exception& ex) {
+        std::cerr << "Failed to read KiBugCheckData: " << ex.what() << "\n";
+        rc = 1;
+    }
+
+    domain->resume();
+    return rc;
+}

--- a/tools/ivexec.cc
+++ b/tools/ivexec.cc
@@ -215,8 +215,26 @@ class ExecFileTool final : public EventCallback {
         // PsCreateFailExeName). Fall back to the legacy \??\ DosDevices alias if
         // resolution fails (Win10 path / non-drive-letter targets).
         std::string nt_image_path = resolve_nt_device_path(target_);
-        if (nt_image_path.empty())
+        if (nt_image_path.empty()) {
+            // A drive-letter target that failed the \GLOBAL?? walk falls back
+            // to the legacy "\??\X:" alias, which is INVALID in the injected
+            // Win11 victim context (per-process DosDevices map): then
+            // NtCreateUserProcess fails STATUS_OBJECT_PATH_NOT_FOUND at
+            // PsCreateFailExeName, surfacing only as a generic
+            // CommandFailedException. Warn loudly -- the usual culprit is a
+            // secondary/data volume Windows never gave a normal
+            // \GLOBAL??\X: -> \Device\HarddiskVolumeN symlink, e.g. the disk's
+            // MBR partition type is 0x83 (Linux) rather than a Windows FAT/NTFS
+            // type (0x06/0x0b/0x0c/0x0e/0x07); re-type the partition.
+            if (target_.size() >= 2 && target_[1] == ':')
+                std::cerr << "WARNING: could not resolve \\Device\\HarddiskVolumeN for \""
+                          << target_.substr(0, 2)
+                          << "\" via \\GLOBAL??; falling back to \\??\\ (invalid in the "
+                             "injected Win11 context). If the launch fails at "
+                             "PsCreateFailExeName, check the target volume has a Windows "
+                             "partition type, not 0x83/Linux.\n";
             nt_image_path = "\\??\\" + target_;
+        }
         const std::string current_dir =
             directory_.empty() ? std::string("C:\\Windows\\System32\\") : directory_;
         const std::string desktop = "Winsta0\\Default";

--- a/tools/ivexec.cc
+++ b/tools/ivexec.cc
@@ -25,15 +25,35 @@
 #include "shared/SystemCallMonitor.hh"
 
 #include <introvirt/introvirt.hh>
+#include <introvirt/linux/inject/syscall.hh>
+
+// Win11-compatible launch via NtCreateUserProcess syscall injection
+#include <introvirt/windows/kernel/nt/NtKernel.hh>
+#include <introvirt/windows/kernel/nt/const/ObjectType.hh>
+#include <introvirt/windows/kernel/nt/const/ProcessCreateFlags.hh>
+#include <introvirt/windows/kernel/nt/const/ThreadCreateFlags.hh>
+#include <introvirt/windows/kernel/nt/syscall/NtCreateUserProcess.hh>
+#include <introvirt/windows/kernel/nt/syscall/types/PS_CREATE_INFO.hh>
+#include <introvirt/windows/kernel/nt/types/RTL_USER_PROCESS_PARAMETERS.hh>
+#include <introvirt/windows/kernel/nt/types/access_mask/PROCESS_ACCESS_MASK.hh>
+#include <introvirt/windows/kernel/nt/types/access_mask/THREAD_ACCESS_MASK.hh>
+#include <introvirt/windows/kernel/nt/types/objects/OBJECT.hh>
+#include <introvirt/windows/kernel/nt/types/objects/OBJECT_DIRECTORY.hh>
+#include <introvirt/windows/kernel/nt/types/objects/OBJECT_HEADER.hh>
+#include <introvirt/windows/kernel/nt/types/objects/OBJECT_HEADER_NAME_INFO.hh>
+#include <introvirt/windows/kernel/nt/types/objects/OBJECT_SYMBOLIC_LINK.hh>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 
+#include <cctype>
+#include <chrono>
 #include <csignal>
 #include <cstring>
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <vector>
 
 using namespace introvirt;
 using namespace introvirt::windows;
@@ -81,84 +101,314 @@ class ExecFileTool final : public EventCallback {
           no_window_(no_window), session_id_(session_id), system_call_monitor_(system_call_monitor),
           unsupported_(all) {}
 
+    /*
+     * Resolve a drive-letter-qualified Win32 path ("C:\\dir\\file.exe") to a
+     * session-independent NT object-namespace path
+     * ("\\Device\\HarddiskVolumeN\\dir\\file.exe").
+     *
+     * NtCreateUserProcess opens the PsAttributeImageName value in the context
+     * of the hijacked victim thread. The "\\??\\" prefix is a per-process /
+     * per-session DosDevices alias resolved via the current thread's
+     * EPROCESS.DeviceMap; on Win11 22621 that map may not expose the drive
+     * letter in the injected context, yielding STATUS_OBJECT_PATH_INVALID
+     * (0xC0000039) at PsCreateFailExeName. "\\Device\\HarddiskVolumeN" is a
+     * real, global object with no DeviceMap/session dependency, so it resolves
+     * identically in any thread.
+     *
+     * Resolution mirrors NtKernelImpl::reparse_drive_letters(): walk
+     * RootDirectoryObject() -> the "GLOBAL??" OBJECT_DIRECTORY -> the "X:"
+     * OBJECT_SYMBOLIC_LINK -> LinkTarget(). Returns "" if it cannot resolve,
+     * so the caller can fall back to the legacy "\\??\\" form (Win10 path /
+     * non-drive-letter targets).
+     */
+    std::string resolve_nt_device_path(const std::string& win32_path) const {
+        // Need at least "X:\\..."; first two chars must be a drive letter + ':'.
+        if (win32_path.size() < 3 || win32_path[1] != ':')
+            return "";
+
+        std::string letter(1, static_cast<char>(std::toupper(
+                                  static_cast<unsigned char>(win32_path[0]))));
+        if (!(letter[0] >= 'A' && letter[0] <= 'Z'))
+            return "";
+        letter += ':';
+        const std::string remainder = win32_path.substr(2); // "\\Windows\\System32\\..."
+
+        // KPTI/VCPU-running race: this object-namespace walk reads guest kernel
+        // structures. A single sample can land on a user-CR3 / VCPU-running
+        // moment where root / GLOBAL?? resolve as null or the link target reads
+        // empty (or a read throws), yielding "" -> the caller falls back to
+        // "\??\", which is invalid in the injected Win11 context ->
+        // STATUS_OBJECT_PATH_NOT_FOUND / PsCreateFailOnFileOpen. Retry across
+        // fresh samples so a transient miss doesn't fail the launch; a genuinely
+        // absent drive letter just costs the (bounded) retry budget then falls back.
+        constexpr int kResolveTries = 30;
+        for (int attempt = 0; attempt < kResolveTries; ++attempt) {
+            try {
+                auto& kernel = guest_.kernel();
+                auto root = kernel.RootDirectoryObject();
+                if (root) {
+                    // Find the \GLOBAL?? directory (global DosDevices, session-independent).
+                    std::shared_ptr<nt::OBJECT_DIRECTORY> global;
+                    for (const auto& obj : root->objects()) {
+                        const auto& hdr = obj->header();
+                        if (hdr.type() == nt::ObjectType::Directory && hdr.has_name_info() &&
+                            hdr.NameInfo().Name() == "GLOBAL??") {
+                            global = nt::OBJECT_DIRECTORY::make_shared(kernel, obj->ptr());
+                            break;
+                        }
+                    }
+                    // Find the "X:" symbolic link and read its target device path.
+                    if (global) {
+                        for (const auto& obj : global->objects()) {
+                            const auto& hdr = obj->header();
+                            if (hdr.type() != nt::ObjectType::SymbolicLink || !hdr.has_name_info())
+                                continue;
+                            if (!boost::iequals(hdr.NameInfo().Name(), letter))
+                                continue;
+
+                            auto link = nt::OBJECT_SYMBOLIC_LINK::make_shared(kernel, obj->ptr());
+                            std::string target = link->LinkTarget(); // e.g. "\\Device\\HarddiskVolume3"
+                            if (!target.empty()) {
+                                // Strip a trailing backslash before appending remainder.
+                                if (target.back() == '\\')
+                                    target.pop_back();
+                                return target + remainder; // "\\Device\\HarddiskVolume3\\Windows\\...\\file.exe"
+                            }
+                        }
+                    }
+                }
+            } catch (std::exception& ex) {
+                // transient racy walk; resample on the next attempt
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+        }
+        return "";
+    }
+
     /**
      * @brief Perform the actual injection to launch a process in the guest
      */
     bool launch(WindowsEvent& wevent) {
-        bool result;
-
-        // Allocate STARTUPINFO, which holds the launch settings
-        // We mostly leave it zeroed
-        auto startupinfo = inject::allocate<STARTUPINFOW>();
-        if (no_window_) {
-            startupinfo->dwFlags(STARTF_USESHOWWINDOW);
-            startupinfo->wShowWindow(SW_HIDE);
-        }
-
-        const uint32_t dwCreationFlags = kernel32::CREATE_SUSPENDED | CREATE_NEW_CONSOLE |
-                                         CREATE_UNICODE_ENVIRONMENT | NORMAL_PRIORITY_CLASS;
-
-        // Structure that gets populated by CreateProcessA with results
-        auto procinfo = inject::allocate<kernel32::PROCESS_INFORMATION>();
+        /*
+         * Launch the target via direct NtCreateUserProcess syscall injection.
+         *
+         * The previous implementation redirected RIP to call CreateProcessW
+         * (function-call injection). On Windows 11 22621 the redirected
+         * CreateProcessW faults when executed and bugchecks the guest
+         * (IRQL_NOT_LESS_OR_EQUAL). Syscall injection is stable on both Win10
+         * and Win11, so we build the structures CreateProcessW would otherwise
+         * construct (RTL_USER_PROCESS_PARAMETERS / PS_ATTRIBUTE_LIST /
+         * PS_CREATE_INFO) ourselves and invoke NtCreateUserProcess directly.
+         */
+        auto& kernel = guest_.kernel();
 
         std::string cmdline = target_;
         if (!args_.empty())
             cmdline += ' ' + args_;
 
-        auto guest_cmdline = inject::allocate(Utf16String::convert(cmdline));
-        guest_ptr<char16_t[]> pguest_directory;
+        // The NT path is what NtCreateUserProcess uses to open the image; it is
+        // passed via the PsAttributeImageName process attribute and resolved in
+        // the injected victim thread's object/DeviceMap context. Prefer a
+        // session-independent \Device\HarddiskVolumeN path (Win11-safe, since
+        // "\??\" is a per-session/per-process DosDevices alias that may not
+        // expose the drive letter in the injected context -> 0xC0000039 at
+        // PsCreateFailExeName). Fall back to the legacy \??\ DosDevices alias if
+        // resolution fails (Win10 path / non-drive-letter targets).
+        std::string nt_image_path = resolve_nt_device_path(target_);
+        if (nt_image_path.empty())
+            nt_image_path = "\\??\\" + target_;
+        const std::string current_dir =
+            directory_.empty() ? std::string("C:\\Windows\\System32\\") : directory_;
+        const std::string desktop = "Winsta0\\Default";
 
-        std::optional<inject::GuestAllocation<char16_t[]>> guest_directory;
-        if (!directory_.empty()) {
-            guest_directory.emplace(inject::allocate(Utf16String::convert(directory_)));
-            pguest_directory = guest_directory->ptr();
+        // UTF-16 path strings, each its own guest allocation. The parameter
+        // block is NORMALIZED, so it references these by absolute pointer.
+        const std::u16string wImage = Utf16String::convert(target_);
+        const std::u16string wCmd = Utf16String::convert(cmdline);
+        const std::u16string wCurDir = Utf16String::convert(current_dir);
+        const std::u16string wDesktop = Utf16String::convert(desktop);
+        const std::u16string wNtImage = Utf16String::convert(nt_image_path);
+
+        // NT image path (referenced by the attribute list) is a separate allocation.
+        auto sNtImage = inject::allocate(wNtImage);
+
+        // Minimal empty environment: a single UTF-16 NUL pair (double-null).
+        auto env = inject::allocate<uint8_t[]>(4);
+        {
+            auto e = env.ptr();
+            for (int i = 0; i < 4; ++i)
+                e[i] = 0;
         }
 
-        // Call CreateProcessA in the guest
-        result = inject::function_call<CreateProcessW>(nullptr, guest_cmdline, nullptr, nullptr,
-                                                       false, dwCreationFlags, nullptr,
-                                                       pguest_directory, startupinfo, procinfo);
+        // ----- Build RTL_USER_PROCESS_PARAMETERS (x64), strings appended inline -----
+        // RtlCreateProcessParametersEx lays the path strings out immediately after
+        // the fixed header within the same block; each UNICODE_STRING.Buffer points
+        // within [block, block+Length]. We reproduce that exactly.
+        //
+        // HDR must cover the FULL fixed header so trailing members
+        // (EnvironmentSize@0x3F0, EnvironmentVersion@0x3F8, PackageDependencyData@0x400,
+        // ProcessGroupId@0x408, LoaderThreads@0x40C, RedirectionDllName/HeapPartitionName/
+        // DefaultThreadpoolCpuSetMasks...) are present and zeroed. On Win11 22H2 x64
+        // sizeof(RTL_USER_PROCESS_PARAMETERS) is 0x440; using 0x410 would let the inline
+        // path strings overlap those defined members.
+        constexpr size_t HDR = 0x440;
+        auto bytes = [](const std::u16string& s) { return (s.length() + 1) * 2; };
+        const size_t offImage = HDR;
+        const size_t offCmd = offImage + bytes(wImage);
+        const size_t offCurDir = offCmd + bytes(wCmd);
+        const size_t offDesktop = offCurDir + bytes(wCurDir);
+        const size_t TOTAL = offDesktop + bytes(wDesktop);
 
-        if (result) {
-            std::cerr << "Created process [" << procinfo->dwProcessId() << ':'
-                      << procinfo->dwThreadId() << "]\n";
+        auto rupp = inject::allocate<uint8_t[]>(TOTAL);
+        const uint64_t G = rupp.address();
 
-            // Update this so we can track the new process
-            new_pid_ = procinfo->dwProcessId();
+        std::vector<uint8_t> b(TOTAL, 0);
+        auto put16 = [&](size_t o, uint16_t v) {
+            b[o] = v & 0xff;
+            b[o + 1] = (v >> 8) & 0xff;
+        };
+        auto put32 = [&](size_t o, uint32_t v) {
+            for (int i = 0; i < 4; ++i)
+                b[o + i] = (v >> (8 * i)) & 0xff;
+        };
+        auto put64 = [&](size_t o, uint64_t v) {
+            for (int i = 0; i < 8; ++i)
+                b[o + i] = (v >> (8 * i)) & 0xff;
+        };
+        auto putStr = [&](size_t o, const std::u16string& s) {
+            for (size_t i = 0; i < s.size(); ++i) {
+                b[o + i * 2] = s[i] & 0xff;
+                b[o + i * 2 + 1] = (s[i] >> 8) & 0xff;
+            }
+        };
+        // UNICODE_STRING { USHORT Length; USHORT MaximumLength; <pad>; PWSTR Buffer; }
+        auto putUS = [&](size_t field, size_t stroff, const std::u16string& s) {
+            put16(field, s.length() * 2);             // Length (bytes, no NUL)
+            put16(field + 2, (s.length() + 1) * 2);   // MaximumLength (incl NUL)
+            put64(field + 8, G + stroff);             // Buffer (absolute, within block)
+        };
 
-            // Reconfigure the task filter for our new PID
-            domain_.task_filter().clear();
-            domain_.task_filter().add_pid(new_pid_);
+        putStr(offImage, wImage);
+        putStr(offCmd, wCmd);
+        putStr(offCurDir, wCurDir);
+        putStr(offDesktop, wDesktop);
 
-            if (admin_) {
-                auto handle_table = wevent.task().pcr().CurrentThread().Process().ObjectTable();
-                auto new_process = handle_table->ProcessObject(procinfo->hProcess());
-                auto& token = new_process->Token();
-                token.PrivilegesPresent(0xFFFFFFFFFFFFFFFF);
-                token.PrivilegesEnabled(0xFFFFFFFFFFFFFFFF);
+        put32(0x00, TOTAL);                  // MaximumLength
+        put32(0x04, TOTAL);                  // Length
+        put32(0x08, 0x1);                    // Flags = NORMALIZED
+        putUS(0x38, offCurDir, wCurDir);     // CurrentDirectory.DosPath (Handle @0x48 = 0)
+        putUS(0x60, offImage, wImage);       // ImagePathName
+        putUS(0x70, offCmd, wCmd);           // CommandLine
+        put64(0x80, env.address());          // Environment
+        putUS(0xB0, offImage, wImage);       // WindowTitle (reuse inline image buffer)
+        putUS(0xC0, offDesktop, wDesktop);   // DesktopInfo
+        put64(0x3F0, 4);                     // EnvironmentSize
 
-                for (auto& group : token.Groups()) {
-                    if (group->Attributes().SE_GROUP_USE_FOR_DENY_ONLY()) {
-                        SID_AND_ATTRIBUTES::SidAttributeFlags new_flags(
-                            SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_ENABLED);
-                        group->Attributes(new_flags);
-                    }
+        {
+            auto p = rupp.ptr();
+            for (size_t i = 0; i < TOTAL; ++i)
+                p[i] = b[i];
+        }
+
+        // ----- Build PS_ATTRIBUTE_LIST with one PsAttributeImageName entry -----
+        // PS_ATTRIBUTE_LIST { SIZE_T TotalLength; PS_ATTRIBUTE Attributes[1]; }
+        // PS_ATTRIBUTE { ULONG_PTR Attribute; SIZE_T Size; ULONG_PTR Value; PSIZE_T ReturnLength; }
+        constexpr size_t AL_SIZE = 0x28;
+        std::vector<uint8_t> al(AL_SIZE, 0);
+        auto putAL = [&](size_t o, uint64_t v) {
+            for (int i = 0; i < 8; ++i)
+                al[o + i] = (v >> (8 * i)) & 0xff;
+        };
+        // Attribute@0x08 is intentionally written 0 here and set below via the typed
+        // PS_ATTRIBUTE setters, so the encoding is exactly the canonical
+        // PsAttributeImageName = num 5 | PS_ATTRIBUTE_INPUT (0x20005). Hand-writing it
+        // previously produced 0x60005 (an extra 0x40000 "additive/unknown" bit) which
+        // PspValidateAttributeList rejects during early create-context build (before the
+        // image file is opened), yielding STATUS_INVALID_PARAMETER with
+        // PS_CREATE_INFO.State left at PsCreateInitialState.
+        putAL(0x00, AL_SIZE);                  // TotalLength
+        putAL(0x08, 0);                        // Attribute (set via typed setters below)
+        putAL(0x10, wNtImage.length() * 2);    // Size (bytes, no NUL)
+        putAL(0x18, sNtImage.address());       // Value -> NT image path
+        putAL(0x20, 0);                        // ReturnLength
+        auto attrlist = inject::allocate<uint8_t[]>(AL_SIZE);
+        {
+            auto p = attrlist.ptr();
+            for (size_t i = 0; i < AL_SIZE; ++i)
+                p[i] = al[i];
+        }
+
+        // Encode the attribute number/flags via IntroVirt's typed PS_ATTRIBUTE setters
+        // so the value is provably 0x20005 (PsAttributeImageName, input-only,
+        // non-thread, non-additive) rather than a hand-packed constant.
+        {
+            auto pal_set = PS_ATTRIBUTE_LIST::make_unique(kernel, attrlist);
+            auto& attr = (*pal_set)[0];
+            attr.AttributeNumber(PsAttributeImageName); // num 5
+            attr.AttributeInputOnly(true);              // PS_ATTRIBUTE_INPUT (0x20000)
+            attr.AttributeThreads(false);               // not a thread attribute
+        }
+
+        // ----- PS_CREATE_INFO: Size = sizeof (0x58), State = PsCreateInitialState (0) -----
+        constexpr size_t PSCI_SIZE = 0x58;
+        auto psci_buf = inject::allocate<uint8_t[]>(PSCI_SIZE);
+        {
+            auto p = psci_buf.ptr();
+            for (size_t i = 0; i < PSCI_SIZE; ++i)
+                p[i] = 0;
+            for (int i = 0; i < 8; ++i)
+                p[i] = (PSCI_SIZE >> (8 * i)) & 0xff; // Size
+        }
+
+        auto procParams = RTL_USER_PROCESS_PARAMETERS::make_unique(kernel, rupp);
+        auto createInfo = PS_CREATE_INFO::make_unique(kernel, psci_buf);
+
+        uint64_t hProcess = 0, hThread = 0;
+        const guest_ptr<void> nullAttr;
+
+        NTSTATUS status = inject::system_call<nt::NtCreateUserProcess>(
+            hProcess, hThread, PROCESS_ACCESS_MASK(0x1FFFFF), THREAD_ACCESS_MASK(0x1FFFFF), nullAttr,
+            nullAttr, ProcessCreateFlags(0), ThreadCreateFlags(nt::CREATE_SUSPENDED), procParams.get(),
+            *createInfo, attrlist);
+
+        if (!status.NT_SUCCESS() || hProcess == 0) {
+            std::cerr << "Failed to launch process: NtCreateUserProcess returned " << status
+                      << " (0x" << std::hex << status.value() << std::dec << ")"
+                      << " PS_CREATE_INFO.State=" << createInfo->State() << '\n';
+            return false;
+        }
+
+        // Resolve the new process from its handle (handle lives in the launcher's table).
+        auto handle_table = wevent.task().pcr().CurrentThread().Process().ObjectTable();
+        auto new_process = handle_table ? handle_table->ProcessObject(hProcess) : nullptr;
+        new_pid_ = new_process ? new_process->UniqueProcessId() : 0;
+
+        std::cerr << "Created process [" << new_pid_ << "]\n";
+
+        // Reconfigure the task filter for our new PID
+        domain_.task_filter().clear();
+        domain_.task_filter().add_pid(new_pid_);
+
+        if (admin_ && new_process) {
+            auto& token = new_process->Token();
+            token.PrivilegesPresent(0xFFFFFFFFFFFFFFFF);
+            token.PrivilegesEnabled(0xFFFFFFFFFFFFFFFF);
+
+            for (auto& group : token.Groups()) {
+                if (group->Attributes().SE_GROUP_USE_FOR_DENY_ONLY()) {
+                    SID_AND_ATTRIBUTES::SidAttributeFlags new_flags(
+                        SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_ENABLED);
+                    group->Attributes(new_flags);
                 }
             }
-
-            // No longer have a need for the process handle
-            inject::system_call<nt::NtClose>(procinfo->hProcess());
-
-            // Resume the suspended thread
-            inject::system_call<nt::NtResumeThread>(procinfo->hThread(), nullptr);
-
-            // No longer have a need for the thread handle
-            inject::system_call<nt::NtClose>(procinfo->hThread());
-        } else {
-            std::cerr << "Failed to launch process: " << GetLastError() << std::endl;
         }
 
-        return result;
+        // Close the process handle, resume the suspended thread, close the thread handle.
+        inject::system_call<nt::NtClose>(hProcess);
+        inject::system_call<nt::NtResumeThread>(hThread, nullptr);
+        inject::system_call<nt::NtClose>(hThread);
+
+        return true;
     }
 
     bool matches_session_id(WindowsEvent& event) const {
@@ -370,6 +620,95 @@ class ExecFileTool final : public EventCallback {
     const bool unsupported_;
 };
 
+/*
+ * Native-Linux process launch via fork()+execve() injection.
+ *
+ * execve replaces the current process image, so injecting it directly would
+ * kill the host process. Instead we fork() a child from a victim process, then
+ * execve() the target *in the child* (the victim survives). Two phases keyed on
+ * the child's pid:
+ *   1. On the first syscall event, inject fork() in the victim → child pid.
+ *   2. The fork's child shares the victim's comm, so its syscall events are
+ *      delivered too; on the first event with task().pid() == child, inject
+ *      execve(target, argv, envp). The child becomes the sample.
+ */
+class LinuxExecTool final : public EventCallback {
+  public:
+    LinuxExecTool(std::string path, std::vector<std::string> argv, std::vector<std::string> envp)
+        : path_(std::move(path)), argv_(std::move(argv)), envp_(std::move(envp)) {}
+
+    int result() const { return result_; }
+
+    void process_event(Event& event) override {
+        if (unlikely(event.type() == EventType::EVENT_SHUTDOWN ||
+                     event.type() == EventType::EVENT_REBOOT)) {
+            exit(64);
+        }
+        if (event.type() != EventType::EVENT_FAST_SYSCALL)
+            return;
+
+        if (phase_ == Phase::Fork) {
+            const int64_t child = linux_guest::inject::inject_fork(event);
+            if (child <= 0) {
+                std::cerr << "fork injection failed: " << child << '\n';
+                event.domain().interrupt();
+                return;
+            }
+            child_pid_ = static_cast<uint64_t>(child);
+            std::cout << "Forked child pid " << child_pid_ << "; awaiting its first syscall\n";
+            phase_ = Phase::Exec;
+            return;
+        }
+
+        if (phase_ == Phase::Exec) {
+            if (event.task().pid() != child_pid_)
+                return; // not our child yet
+            const int64_t r = linux_guest::inject::execve(event, path_, argv_, envp_);
+            // execve only returns on failure.
+            if (r < 0)
+                std::cerr << "execve injection failed: " << r << '\n';
+            else
+                std::cout << "Launched " << path_ << " in pid " << child_pid_ << '\n';
+            result_ = (r < 0) ? 1 : 0;
+            phase_ = Phase::Done;
+            event.domain().interrupt();
+        }
+    }
+
+  private:
+    enum class Phase { Fork, Exec, Done };
+    Phase phase_ = Phase::Fork;
+    const std::string path_;
+    const std::vector<std::string> argv_;
+    const std::vector<std::string> envp_;
+    uint64_t child_pid_ = 0;
+    int result_ = 1;
+};
+
+static int run_linux_exec(Domain& domain, const std::string& target,
+                          const std::string& arguments, const std::string& process_name,
+                          bool procname_set) {
+    std::vector<std::string> argv{target};
+    if (!arguments.empty()) {
+        std::vector<std::string> parts;
+        boost::split(parts, arguments, boost::is_any_of(" "), boost::token_compress_on);
+        for (auto& p : parts)
+            if (!p.empty())
+                argv.push_back(p);
+    }
+    const std::vector<std::string> envp{
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOME=/root"};
+
+    // Host the fork in a named victim if given, else any process that syscalls.
+    if (procname_set)
+        domain.task_filter().add_name(process_name);
+
+    domain.intercept_system_calls(true);
+    LinuxExecTool tool(target, argv, envp);
+    domain.poll(tool);
+    return tool.result();
+}
+
 int main(int argc, char** argv) {
     po::options_description desc("Options");
     std::string domain_name;
@@ -425,6 +764,13 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        if (domain->guest()->os() == OS::Linux) {
+            // Native-Linux launch via fork()+execve() injection (self-contained;
+            // the Windows path below is untouched).
+            return run_linux_exec(*domain, target_file, arguments, process_name,
+                                  !vm["procname"].defaulted());
+        }
+
         if (domain->guest()->os() != OS::Windows) {
             std::cerr << "Unsupported OS: " << domain->guest()->os() << '\n';
             return 1;
@@ -468,25 +814,45 @@ int main(int argc, char** argv) {
         guest->set_system_call_filter(domain->system_call_filter(),
                                       SystemCallIndex::NtTerminateProcess, true);
 
-        // Get the session id for the target process
+        // Get the session id for the target process.
+        // KPTI/VCPU-running race: a single CidTable walk can land on a user-CR3 /
+        // VCPU-running moment where the kernel reads (CidTable / open_handles /
+        // ObjectHeader / process->Session()) transiently fail. The original
+        // single-shot walk then reported "Failed to find the session ID"; worse,
+        // CidTable()/open_handles() sat OUTSIDE the per-entry try, so a raced read
+        // there threw a CommandFailedException ("Cannot access register state
+        // while VCPU is running") straight to std::terminate. Retry the whole walk
+        // across fresh samples, catching the walk-level read as well.
         uint64_t session_id = 0xFFFFFFFFFFFFFFFF;
         auto& kernel = guest->kernel();
-        auto CidTable = kernel.CidTable();
-        auto handles = CidTable->open_handles();
-        for (auto& entry : handles) {
+        constexpr int kSessionTries = 40;
+        for (int attempt = 0;
+             attempt < kSessionTries && session_id == 0xFFFFFFFFFFFFFFFF; ++attempt) {
             try {
-                if (entry->ObjectHeader()->type() == ObjectType::Process) {
-                    auto process = kernel.process(entry->ObjectHeader()->Body());
-                    if (boost::istarts_with(process->ImageFileName(), process_name)) {
-                        // Found the target process
-                        if (process->Session()) {
-                            session_id = process->Session()->SessionID();
-                            break;
+                auto CidTable = kernel.CidTable();
+                auto handles = CidTable->open_handles();
+                for (auto& entry : handles) {
+                    try {
+                        if (entry->ObjectHeader()->type() == ObjectType::Process) {
+                            auto process = kernel.process(entry->ObjectHeader()->Body());
+                            if (boost::istarts_with(process->ImageFileName(), process_name)) {
+                                // Found the target process
+                                if (process->Session()) {
+                                    session_id = process->Session()->SessionID();
+                                    break;
+                                }
+                            }
                         }
+                    } catch (TraceableException& ex) {
+                        // racy per-entry read; skip this entry
                     }
                 }
             } catch (TraceableException& ex) {
+                // racy walk-level read (CidTable/open_handles unreadable at this
+                // CR3); resample on the next attempt
             }
+            if (session_id == 0xFFFFFFFFFFFFFFFF)
+                std::this_thread::sleep_for(std::chrono::milliseconds(40));
         }
 
         if (session_id == 0xFFFFFFFFFFFFFFFF) {

--- a/tools/ivguestinfo.cc
+++ b/tools/ivguestinfo.cc
@@ -24,6 +24,9 @@
 
 #include <introvirt/introvirt.hh>
 
+#include <introvirt/linux/LinuxGuest.hh>
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 
@@ -123,6 +126,15 @@ int main(int argc, char** argv) {
     auto* guest = domain->guest();
     if (guest->os() == OS::Windows) {
         print_guest_information(static_cast<WindowsGuest&>(*guest), vm);
+    } else if (guest->os() == OS::Linux) {
+        const auto& kernel = static_cast<linux_guest::LinuxGuest*>(guest)->kernel();
+        std::cout << "Detected Linux\n";
+        std::cout << "  Release: " << kernel.release() << '\n';
+        std::cout << "  Banner: " << kernel.banner() << '\n';
+        std::cout << std::hex;
+        std::cout << "  Kernel base: 0x" << kernel.base_address() << '\n';
+        std::cout << "  KASLR slide: 0x" << kernel.kaslr_slide() << '\n';
+        std::cout << std::dec;
     }
 
     // Resume it

--- a/tools/ivmemwatch.cc
+++ b/tools/ivmemwatch.cc
@@ -24,6 +24,9 @@
 
 #include <introvirt/introvirt.hh>
 
+#include <introvirt/linux/LinuxGuest.hh>
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 
@@ -201,6 +204,41 @@ int main(int argc, char** argv) {
         guest_ptr<void> ptr(*domain, address, process->DirectoryTableBase());
 
         // Create the watchpoint
+        watchpoint =
+            domain->create_watchpoint(ptr, length, read, write, exec, std::bind(&mem_callback, _1));
+
+        break;
+    }
+    case OS::Linux: {
+        // Find the target task, then translate `address` in its address space
+        // via the process page directory (mm->pgd, physical).
+        const auto& kernel =
+            static_cast<linux_guest::LinuxGuest*>(domain->guest())->kernel();
+        uint64_t task_address = 0;
+        for (const auto& process : kernel.processes()) {
+            if (vm.count("pid") == 0) {
+                if (boost::starts_with(boost::to_lower_copy(process.name()), process_name)) {
+                    task_address = process.task_struct_address();
+                    break;
+                }
+            } else if (static_cast<uint64_t>(process.pid()) == pid) {
+                task_address = process.task_struct_address();
+                break;
+            }
+        }
+
+        if (task_address == 0) {
+            std::cerr << "Failed to find a matching process\n";
+            return 1;
+        }
+
+        const uint64_t page_directory = kernel.process_page_directory(task_address);
+        if (page_directory == 0) {
+            std::cerr << "Failed to resolve the process page directory\n";
+            return 1;
+        }
+
+        guest_ptr<void> ptr(*domain, address, page_directory);
         watchpoint =
             domain->create_watchpoint(ptr, length, read, write, exec, std::bind(&mem_callback, _1));
 

--- a/tools/ivprocinfo.cc
+++ b/tools/ivprocinfo.cc
@@ -24,6 +24,9 @@
 
 #include <introvirt/introvirt.hh>
 
+#include <introvirt/linux/LinuxGuest.hh>
+#include <introvirt/linux/kernel/LinuxKernel.hh>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 
@@ -424,6 +427,21 @@ int main(int argc, char** argv) {
 
     // Parse Windows information
     auto* guest = domain->guest();
+
+    // Linux guests: render the task list via the native LinuxKernel API
+    // (init_task.tasks walk). This is the first iv* tool with a Linux path.
+    if (guest->os() == OS::Linux) {
+        const auto& kernel = static_cast<linux_guest::LinuxGuest*>(guest)->kernel();
+        std::cout << "Linux " << kernel.release() << '\n';
+        for (const auto& process : kernel.processes()) {
+            std::cout << "PID " << process.pid() << ": " << process.name() << " (tid "
+                      << process.tid() << ", task_struct 0x" << std::hex
+                      << process.task_struct_address() << std::dec << ")\n";
+        }
+        domain->resume();
+        return 0;
+    }
+
     if (guest->os() != OS::Windows) {
         std::cerr << "Unsupported OS: " << guest->os() << '\n';
         return 2;

--- a/tools/ivreadfile.cc
+++ b/tools/ivreadfile.cc
@@ -24,6 +24,7 @@
  */
 
 #include <introvirt/introvirt.hh>
+#include <introvirt/linux/inject/syscall.hh>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
@@ -144,6 +145,28 @@ class ReadFileTool final : public EventCallback {
         */
     }
 
+    // Linux: openat(O_RDONLY) + read loop + close, injected via the guest.
+    void copy_linux(Event& event) {
+        result_ = 1;
+        constexpr size_t kMax = static_cast<size_t>(1) << 31; // 2 GiB cap
+        const std::vector<uint8_t> bytes =
+            linux_guest::inject::read_file(event, src_path_, kMax);
+
+        FILE* dst_file = fopen(dst_path_.c_str(), "wb");
+        if (!dst_file) {
+            std::cout << "Failed to open destination file: " << strerror(errno) << '\n';
+            return;
+        }
+        const size_t w = fwrite(bytes.data(), 1, bytes.size(), dst_file);
+        fclose(dst_file);
+        if (w != bytes.size()) {
+            std::cout << "Short write to destination file\n";
+            return;
+        }
+        std::cout << "Read " << bytes.size() << " bytes from " << src_path_ << '\n';
+        result_ = 0;
+    }
+
     void process_event(Event& event) override {
         if (unlikely(event.type() == EventType::EVENT_SHUTDOWN ||
                      event.type() == EventType::EVENT_REBOOT)) {
@@ -152,20 +175,24 @@ class ReadFileTool final : public EventCallback {
 
         if (event.type() == EventType::EVENT_FAST_SYSCALL) {
             if (copy_started_.test_and_set() == 0) {
-                copy();
+                if (is_linux_)
+                    copy_linux(event);
+                else
+                    copy();
                 event.domain().interrupt();
             }
         }
     }
 
-    ReadFileTool(const std::string& src_path, const std::string& dst_path)
-        : src_path_(src_path), dst_path_(dst_path) {}
+    ReadFileTool(const std::string& src_path, const std::string& dst_path, bool is_linux)
+        : src_path_(src_path), dst_path_(dst_path), is_linux_(is_linux) {}
 
     int result() const { return result_; }
 
   private:
     const std::string src_path_;
     const std::string dst_path_;
+    const bool is_linux_;
 
     int result_;
 
@@ -208,19 +235,22 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    if (domain->guest()->os() != OS::Windows) {
+    const bool is_linux = (domain->guest()->os() == OS::Linux);
+    if (domain->guest()->os() != OS::Windows && !is_linux) {
         std::cerr << "Unsupported OS: " << domain->guest()->os() << '\n';
         return 1;
     }
 
-    // Set our process name filter
-    domain->task_filter().add_name(process_name);
+    // Process filter: Windows hijacks the named process; Linux injects in the
+    // first process to make a syscall unless one was explicitly named.
+    if (!is_linux || !vm["process_name"].defaulted())
+        domain->task_filter().add_name(process_name);
 
     // Enable system call hooking on all vcpus
     domain->intercept_system_calls(true);
 
     // Start the poll
-    ReadFileTool tool(source_file, dest_file);
+    ReadFileTool tool(source_file, dest_file, is_linux);
     domain->poll(tool);
     return tool.result();
 }

--- a/tools/ivsyscallmon.cc
+++ b/tools/ivsyscallmon.cc
@@ -95,27 +95,26 @@ int main(int argc, char** argv) {
         domain->task_filter().add_name(process_name);
     }
 
-    // Turn on system call filtering unless hooking all calls
-    if (vm.count("unsupported") == 0) {
+    // Turn on system call filtering unless hooking all calls. Category-based
+    // filtering is Windows-only for now; on a Linux guest we leave the filter
+    // disabled so intercept_system_calls() below captures every syscall (an
+    // enabled-but-empty filter would otherwise mask them all).
+    if (vm.count("unsupported") == 0 && domain->guest()->os() == OS::Windows) {
         bool category_used = false;
         domain->system_call_filter().enabled(true);
 
-        if (domain->guest()->os() == OS::Windows) {
-            for (auto& category : WindowsGuest::syscall_categories()) {
-                if (vm.count(category)) {
-                    auto* guest = static_cast<WindowsGuest*>(domain->guest());
-                    guest->enable_category(category, domain->system_call_filter());
-                    category_used = true;
-                }
+        for (auto& category : WindowsGuest::syscall_categories()) {
+            if (vm.count(category)) {
+                auto* guest = static_cast<WindowsGuest*>(domain->guest());
+                guest->enable_category(category, domain->system_call_filter());
+                category_used = true;
             }
         }
 
         if (!category_used) {
             // Default to all supported calls
-            if (domain->guest()->os() == OS::Windows) {
-                auto* guest = static_cast<WindowsGuest*>(domain->guest());
-                guest->default_syscall_filter(domain->system_call_filter());
-            }
+            auto* guest = static_cast<WindowsGuest*>(domain->guest());
+            guest->default_syscall_filter(domain->system_call_filter());
         }
     }
 

--- a/tools/ivwritefile.cc
+++ b/tools/ivwritefile.cc
@@ -23,6 +23,7 @@
  */
 
 #include <introvirt/introvirt.hh>
+#include <introvirt/linux/inject/syscall.hh>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
@@ -31,6 +32,7 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <sys/stat.h>
@@ -169,6 +171,33 @@ class WriteFileTool final : public EventCallback {
         fclose(src_file);
     }
 
+    // Linux: openat(O_CREAT|O_WRONLY|O_TRUNC) + write + close, injected into the
+    // current process via linux_guest::inject::write_file. No \??\ path mangling.
+    void copy_linux(Event& event) {
+        result_ = 1;
+        FILE* src_file = fopen(src_path_.c_str(), "rb");
+        if (!src_file) {
+            std::cout << "Failed to open source file: " << strerror(errno) << '\n';
+            return;
+        }
+        std::string bytes;
+        char chunk[65536];
+        size_t n;
+        while ((n = fread(chunk, 1, sizeof(chunk), src_file)) > 0)
+            bytes.append(chunk, n);
+        fclose(src_file);
+
+        const int64_t written =
+            linux_guest::inject::write_file(event, dst_path_, bytes.data(), bytes.size(), mode_);
+        if (written < 0 || static_cast<size_t>(written) != bytes.size()) {
+            std::cout << "Failed to write guest file (wrote " << written << " of "
+                      << bytes.size() << " bytes)\n";
+            return;
+        }
+        std::cout << "Wrote " << written << " bytes to " << dst_path_ << '\n';
+        result_ = 0;
+    }
+
     void process_event(Event& event) override {
         if (unlikely(event.type() == EventType::EVENT_SHUTDOWN ||
                      event.type() == EventType::EVENT_REBOOT)) {
@@ -177,15 +206,19 @@ class WriteFileTool final : public EventCallback {
 
         if (event.type() == EventType::EVENT_FAST_SYSCALL) {
             if (copy_started_.test_and_set() == 0) {
-
-                copy();
+                if (is_linux_)
+                    copy_linux(event);
+                else
+                    copy();
                 event.domain().interrupt();
             }
         }
     }
 
-    WriteFileTool(const std::string& src_path, const std::string& dst_path, bool progress_bar)
-        : src_path_(src_path), dst_path_(dst_path), progress_bar_(progress_bar) {}
+    WriteFileTool(const std::string& src_path, const std::string& dst_path, bool progress_bar,
+                  bool is_linux, int mode)
+        : src_path_(src_path), dst_path_(dst_path), progress_bar_(progress_bar),
+          is_linux_(is_linux), mode_(mode) {}
 
     int result() const { return result_; }
 
@@ -193,6 +226,8 @@ class WriteFileTool final : public EventCallback {
     const std::string src_path_;
     std::string dst_path_;
     const bool progress_bar_;
+    const bool is_linux_;
+    const int mode_; // POSIX mode bits for the new guest file (Linux only)
 
     int result_;
 
@@ -205,6 +240,7 @@ int main(int argc, char** argv) {
     std::string process_name;
     std::string source_file;
     std::string dest_file;
+    std::string mode_str;
 
     // clang-format off
     desc.add_options()
@@ -212,6 +248,7 @@ int main(int argc, char** argv) {
       ("source_file,s", po::value<std::string>(&source_file)->required(), "The path to the source file")
       ("dest_file,d", po::value<std::string>(&dest_file)->required(), "The destination file path to write in the guest")
       ("process_name,P", po::value<std::string>(&process_name)->default_value("explorer"), "The name of a process to hijack")
+      ("mode,m", po::value<std::string>(&mode_str)->default_value("0644"), "Octal permission bits for the new guest file, e.g. 0755 (Linux guests only)")
       ("progress", "Display a progress bar")
       ("help", "Display program help");
     // clang-format on
@@ -221,6 +258,22 @@ int main(int argc, char** argv) {
 
     po::variables_map vm;
     parse_program_options(argc, argv, desc, vm);
+
+    // Parse --mode as octal (POSIX permission bits). boost does no octal
+    // validation, so do it explicitly and reject anything malformed or out of
+    // the 0..07777 range. Only consulted on Linux guests; ignored on Windows.
+    int mode = 0644;
+    try {
+        size_t pos = 0;
+        const unsigned long parsed = std::stoul(mode_str, &pos, 8);
+        if (pos != mode_str.size() || parsed > 07777)
+            throw std::out_of_range(mode_str);
+        mode = static_cast<int>(parsed);
+    } catch (const std::exception&) {
+        std::cerr << "ERROR: invalid --mode '" << mode_str
+                  << "' (expected octal permission bits, e.g. 0755)\n";
+        return 1;
+    }
 
     // Get a hypervisor instance
     // This will automatically select the correct type of hypervisor.
@@ -236,24 +289,34 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    if (domain->guest()->os() != OS::Windows) {
+    const bool is_linux = (domain->guest()->os() == OS::Linux);
+    if (domain->guest()->os() != OS::Windows && !is_linux) {
         std::cerr << "Unsupported OS: " << domain->guest()->os() << '\n';
         return 1;
     }
 
-    // Set our process name filter
-    domain->task_filter().add_name(process_name);
+    // Process filter: on Windows hijack the named process; on Linux inject in
+    // whatever process triggers the first syscall unless one was named.
+    if (!is_linux) {
+        domain->task_filter().add_name(process_name);
+    } else if (!vm["process_name"].defaulted()) {
+        domain->task_filter().add_name(process_name);
+    }
 
     // Enable system call hooking on all vcpus
     domain->intercept_system_calls(true);
 
-    // If the file ends in a backslash, treat it like a directory and append the source file
-    if (boost::ends_with(dest_file, "\\")) {
+    if (is_linux) {
+        // POSIX path; trailing-slash directory means "drop with the source name".
+        if (boost::ends_with(dest_file, "/"))
+            dest_file += get_filename_from_path(source_file);
+    } else if (boost::ends_with(dest_file, "\\")) {
+        // If the file ends in a backslash, treat it like a directory.
         dest_file += get_filename_from_path(source_file);
     }
 
     // Start the poll
-    WriteFileTool tool(source_file, dest_file, vm.count("progress"));
+    WriteFileTool tool(source_file, dest_file, vm.count("progress"), is_linux, mode);
     domain->poll(tool);
 }
 

--- a/tools/linux/README.md
+++ b/tools/linux/README.md
@@ -1,0 +1,57 @@
+# Linux guest profiles for IntroVirt (SecTepe)
+
+The native Linux guest model (see `docs/introvirt-linux-port.md`) resolves
+kernel symbols and struct member offsets from an **offline-generated
+profile** instead of an in-image PDB. This directory holds the generator.
+
+## What a profile contains
+
+A compact JSON (`sectepe-linux-isf/1`) with exactly what the model walks:
+
+```json
+{
+  "format": "sectepe-linux-isf/1",
+  "metadata": { "arch": "x86_64", "source_producer": "dwarf2json" },
+  "symbols": { "init_task": 18446744071578834944, "_text": ..., "entry_SYSCALL_64": ... },
+  "types":   { "task_struct": { "comm": 1544, "pid": 1232, "tasks": 1080, "mm": 1096 }, ... },
+  "sizes":   { "task_struct": 9216, ... }
+}
+```
+
+Symbol addresses are **link-time** addresses; the live KASLR slide is
+applied at runtime by `LinuxKernel`.
+
+## Generating one
+
+1. Get the **uncompressed `vmlinux`** with DWARF for the guest kernel
+   (the `-dbg`/`-debuginfo` package, or build output). The compressed
+   `vmlinuz` on `/boot` does *not* carry DWARF.
+
+2. Produce a Volatility3 ISF with
+   [`dwarf2json`](https://github.com/volatilityfoundation/dwarf2json):
+
+   ```bash
+   dwarf2json linux --elf vmlinux > vmlinux.isf.json
+   ```
+
+3. Downselect + validate to the SecTepe profile:
+
+   ```bash
+   python3 generate_isf.py --in vmlinux.isf.json \
+       --out ~/.introvirt/profiles/linux-$(uname -r)-x86_64.json
+   ```
+
+   `generate_isf.py` **fails loudly** if the kernel's DWARF is missing any
+   symbol or struct member the model depends on (the `REQUIRED_SYMBOLS` /
+   `REQUIRED_TYPES` manifest at the top of the script) — so an incomplete
+   profile is caught on the build host, not on a live detonation. Use
+   `--check` to validate without writing.
+
+## Versioning notes
+
+- The manifest tolerates kernel-version drift where the layout genuinely
+  changed: the pre-6.1 `mm_struct.mmap` VMA list **or** the >=6.1
+  `mm_struct.mm_mt` maple tree satisfies the memory-map requirement
+  (`OPTIONAL_MEMBERS` in the script).
+- One profile per guest kernel release; the model selects it via
+  `LinuxProfile::load_for_release(release, arch)`.

--- a/tools/linux/generate_isf.py
+++ b/tools/linux/generate_isf.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright 2026 SecTepe.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+"""Generate a compact SecTepe Linux ISF profile for IntroVirt.
+
+IntroVirt's Windows guest model resolves kernel symbols + struct member
+offsets from the PDB embedded in the kernel PE image. Linux has no PDB, so
+the native Linux guest model (see docs/introvirt-linux-port.md) instead
+loads an offline-generated profile: symbol addresses + the handful of
+struct member offsets the model walks (task_struct, mm_struct,
+vm_area_struct, ...).
+
+Rather than re-parse DWARF here, this tool consumes a Volatility3-style ISF
+JSON (produced by `dwarf2json linux --elf vmlinux`) and *downselects* it to
+exactly the symbols and type members IntroVirt needs, emitting a small,
+flat, fast-to-parse JSON that the C++ ``LinuxProfile`` loader reads.
+
+Keeping a curated REQUIRED manifest here means a profile that is missing
+something the model depends on fails loudly at generation time (on the
+build host) instead of at introspection time (on a live detonation).
+
+Usage:
+    generate_isf.py --in vmlinux.isf.json --out linux-<ver>-<arch>.json
+    generate_isf.py --in vmlinux.isf.json --check        # validate only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict, List, Tuple
+
+# Schema version of the *emitted* SecTepe profile (not the Vol3 input).
+PROFILE_FORMAT = "sectepe-linux-isf/1"
+
+# Kernel symbols the Linux guest model resolves. `_text`/`_stext` anchor the
+# KASLR-slide computation against the live MSR_LSTAR / banner; `init_task` is
+# the head of the task list; the syscall entry is the syscall-hook target.
+REQUIRED_SYMBOLS: Tuple[str, ...] = (
+    "init_task",
+    "_text",
+    "_stext",
+    "entry_SYSCALL_64",
+    "current_task",        # per-CPU: resolve the running task from GS base
+    "linux_banner",        # "Linux version ..." — confirms guest is Linux
+    "page_offset_base",    # direct-map base (KASLR): KVA->PA for a process pgd
+)
+
+# Symbols the model uses opportunistically — extracted if present, but their
+# absence does NOT fail profile generation (kernel-version-dependent names).
+OPTIONAL_SYMBOLS: Tuple[str, ...] = (
+    # The kernel's top-level page table (`swapper_pg_dir` on older kernels).
+    # Its *physical* address is a STABLE kernel-mapping CR3 — the model
+    # translates this VA once at detection to read kernel memory from event
+    # handlers without depending on whichever (possibly short-lived) process
+    # CR3 happened to be live at attach.
+    "init_top_pgt",
+    "init_level4_pgt",     # pre-4.13 name
+)
+
+# Struct member offsets the model walks. Keep this in lockstep with the C++
+# LinuxKernelImpl reads; adding a read there means adding the member here.
+REQUIRED_TYPES: Dict[str, Tuple[str, ...]] = {
+    "task_struct": ("tasks", "pid", "tgid", "comm", "mm", "active_mm",
+                    "real_parent", "parent"),
+    "mm_struct": ("pgd", "mmap", "mm_mt"),       # mm_mt: maple-tree on >=6.1
+    "vm_area_struct": ("vm_start", "vm_end", "vm_next", "vm_file", "vm_flags"),
+    "list_head": ("next", "prev"),
+}
+
+# Members that genuinely vary by kernel version — absence is tolerated (the
+# model picks whichever layout the running kernel exposes). Everything else
+# in REQUIRED_TYPES must be present.
+OPTIONAL_MEMBERS = {
+    ("mm_struct", "mmap"),     # removed in favour of mm_mt on >= 6.1
+    ("mm_struct", "mm_mt"),    # absent on < 6.1
+    ("vm_area_struct", "vm_next"),  # gone with the maple-tree rework
+    ("task_struct", "active_mm"),
+    ("task_struct", "parent"),
+}
+
+
+def _member_offset(field: dict) -> int:
+    """Vol3 ISF stores a member as {"offset": N, "type": {...}}."""
+    return int(field["offset"])
+
+
+def _flatten_fields(tinfo: dict, src_types: Dict[str, dict],
+                    base: int = 0, _seen: frozenset = frozenset()) -> Dict[str, int]:
+    """Return {member_name: absolute_offset} for a struct, hoisting members of
+    anonymous nested struct/union aggregates into the parent namespace.
+
+    Modern kernels wrap the body of an aggregate in an anonymous struct for
+    layout/randomisation reasons — e.g. 5.15 ``mm_struct`` keeps ``pgd``,
+    ``mmap`` etc. inside an unnamed inner struct at offset 0, leaving only
+    ``cpu_bitmap`` + the anonymous field at the top level. dwarf2json mirrors
+    this nesting, so a flat ``fields`` scan misses every real member. We
+    recurse into anonymous aggregate members, adding their base offset so the
+    hoisted offsets stay absolute from the outer struct base (what the C++
+    LinuxProfile loader expects)."""
+    flat: Dict[str, int] = {}
+    for name, field in tinfo.get("fields", {}).items():
+        off = base + _member_offset(field)
+        ftype = field.get("type", {})
+        is_anon = bool(field.get("anonymous")) and ftype.get("kind") in ("struct", "union")
+        if is_anon:
+            tname = ftype.get("name")
+            if tname and tname not in _seen:
+                inner = src_types.get(tname)
+                if inner is not None:
+                    for m, o in _flatten_fields(inner, src_types, off,
+                                                _seen | {tname}).items():
+                        flat.setdefault(m, o)
+                    continue
+        # Named members win over any same-named hoisted member.
+        flat[name] = off
+    return flat
+
+
+def build_profile(vol3: dict) -> dict:
+    """Downselect a Volatility3 ISF dict to the SecTepe Linux profile."""
+    src_symbols = vol3.get("symbols", {})
+    src_types = vol3.get("user_types", {})
+    src_meta = vol3.get("metadata", {})
+
+    symbols: Dict[str, int] = {}
+    for name in REQUIRED_SYMBOLS + OPTIONAL_SYMBOLS:
+        entry = src_symbols.get(name)
+        if entry is not None and entry.get("address") is not None:
+            symbols[name] = int(entry["address"])
+
+    types: Dict[str, Dict[str, int]] = {}
+    sizes: Dict[str, int] = {}
+    for struct, members in REQUIRED_TYPES.items():
+        tinfo = src_types.get(struct)
+        if tinfo is None:
+            continue
+        fields = _flatten_fields(tinfo, src_types)
+        member_offsets: Dict[str, int] = {}
+        for member in members:
+            if member in fields:
+                member_offsets[member] = fields[member]
+        types[struct] = member_offsets
+        if tinfo.get("size") is not None:
+            sizes[struct] = int(tinfo["size"])
+
+    # Pull a linux-banner-ish identity through if the input carries it.
+    producer = src_meta.get("producer", {})
+    linux_meta = src_meta.get("linux", {})
+    return {
+        "format": PROFILE_FORMAT,
+        "metadata": {
+            "arch": linux_meta.get("arch") or src_meta.get("arch") or "x86_64",
+            "kernel": (linux_meta.get("kernel") or {}).get("symbols")
+            if isinstance(linux_meta.get("kernel"), dict) else None,
+            "source_producer": producer.get("name"),
+        },
+        "symbols": symbols,
+        "types": types,
+        "sizes": sizes,
+    }
+
+
+def validate(profile: dict) -> List[str]:
+    """Return a list of human-readable problems; empty == complete."""
+    problems: List[str] = []
+    for name in REQUIRED_SYMBOLS:
+        if name not in profile.get("symbols", {}):
+            problems.append(f"missing symbol: {name}")
+    for struct, members in REQUIRED_TYPES.items():
+        tmembers = profile.get("types", {}).get(struct)
+        if tmembers is None:
+            problems.append(f"missing type: {struct}")
+            continue
+        for member in members:
+            if member in tmembers:
+                continue
+            if (struct, member) in OPTIONAL_MEMBERS:
+                continue
+            problems.append(f"missing member: {struct}.{member}")
+    # At least one of the two mm-region layouts (legacy mmap list OR maple
+    # tree) must be resolvable, else the model can't walk the memory map.
+    mm = profile.get("types", {}).get("mm_struct", {})
+    if "mmap" not in mm and "mm_mt" not in mm:
+        problems.append("mm_struct has neither mmap nor mm_mt (no VMA walk)")
+    return problems
+
+
+def main(argv: List[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--in", dest="infile", required=True,
+                    help="Volatility3 ISF JSON (from dwarf2json)")
+    ap.add_argument("--out", dest="outfile",
+                    help="output SecTepe Linux profile JSON")
+    ap.add_argument("--check", action="store_true",
+                    help="validate completeness only; do not write output")
+    args = ap.parse_args(argv)
+
+    with open(args.infile, "r") as fh:
+        vol3 = json.load(fh)
+
+    profile = build_profile(vol3)
+    problems = validate(profile)
+    if problems:
+        sys.stderr.write("INCOMPLETE Linux profile:\n")
+        for p in problems:
+            sys.stderr.write(f"  - {p}\n")
+        return 2
+
+    if args.check:
+        sys.stderr.write("profile complete: %d symbols, %d types\n" % (
+            len(profile["symbols"]), len(profile["types"])))
+        return 0
+
+    if not args.outfile:
+        ap.error("--out is required unless --check is given")
+    with open(args.outfile, "w") as fh:
+        json.dump(profile, fh, indent=2, sort_keys=True)
+    sys.stderr.write("wrote %s (%d symbols, %d types)\n" % (
+        args.outfile, len(profile["symbols"]), len(profile["types"])))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/shared/SystemCallMonitor.hh
+++ b/tools/shared/SystemCallMonitor.hh
@@ -24,8 +24,16 @@ class SystemCallMonitor final : public EventCallback {
         switch (event.type()) {
         case EventType::EVENT_FAST_SYSCALL: {
             SystemCall* syscall = event.syscall().handler();
-            if (unlikely(syscall == nullptr))
-                break; // Shouldn't happen I believe
+            if (syscall == nullptr) {
+                // No per-syscall handler (e.g. a Linux guest, which has no
+                // handler classes yet): we can't decode arguments or hook the
+                // return, so emit the call on entry using its name + task.
+                if (json_)
+                    write_json(event);
+                else
+                    write_syscall(event);
+                break;
+            }
 
             if (!syscall->supported()) {
                 // Handle system calls that aren't technically supported

--- a/win_syscall_generator/generate.py
+++ b/win_syscall_generator/generate.py
@@ -125,6 +125,13 @@ def load_typemap(arg, typemap):
     if 'use_address_for_injection' in arg_type:
         arg['use_address_for_injection'] = arg_type['use_address_for_injection']
 
+    # Opt-in: marshal this complex arg into the injected syscall by pointing the
+    # register at the caller object's own guest buffer (handler.<name>Ptr(obj.ptr())).
+    # Only set on pointer-wrapper impls that expose ptr() (RTL_USER_PROCESS_PARAMETERS,
+    # PS_CREATE_INFO) so NtCreateUserProcess injection passes them instead of NULL.
+    if 'inject_via_ptr' in arg_type:
+        arg['inject_via_ptr'] = arg_type['inject_via_ptr']
+
     if 'helper' in arg_type:
         if 'helper' not in arg:
             arg['helper'] = dict(arg_type['helper'])

--- a/win_syscall_generator/templates/NtSystemCallImpl.hh.tpl
+++ b/win_syscall_generator/templates/NtSystemCallImpl.hh.tpl
@@ -313,6 +313,20 @@ Json::Value json() const override {
                     {%- else %}
     handler.{{ arg['name' ] }}({{ arg['name'] }});
                     {%- endif %}
+                {%- elif arg.get('inject_via_ptr') %}
+                    {#- complex-mode pointer-wrapper object (opt-in via typemap "inject_via_ptr"). #}
+                    {#- The constructor only received a default-constructed NULL guest_ptr for #}
+                    {#- this argument, so without this the kernel is handed a NULL pointer. #}
+                    {#- Point the syscall argument at the caller object's own guest buffer. Only #}
+                    {#- types whose impl exposes ptr() opt in (RTL_USER_PROCESS_PARAMETERS, #}
+                    {#- PS_CREATE_INFO); composite/no-ptr() complex types (KEY_VALUE, #}
+                    {#- FILE_BASIC_INFORMATION, ...) are intentionally excluded. #}
+                    {%- if arg.get('optional') %}
+    if ({{arg['name']}})
+        handler.{{ arg['functionName'] }}({{ arg['name'] }}->ptr());
+                    {%- else %}
+    handler.{{ arg['functionName'] }}({{ arg['name'] }}.ptr());
+                    {%- endif %}
                 {%- endif %}
             {%- endif %}
         {%- endif %}

--- a/win_syscall_generator/typemap.json
+++ b/win_syscall_generator/typemap.json
@@ -430,6 +430,7 @@
         }
     },
     "PS_CREATE_INFO": {
+        "inject_via_ptr": true,
         "includes": [
             "<introvirt/windows/kernel/nt/syscall/types/PS_CREATE_INFO.hh>"
         ],
@@ -470,6 +471,7 @@
         }
     },
     "RTL_USER_PROCESS_PARAMETERS": {
+        "inject_via_ptr": true,
         "includes": [
             "<introvirt/windows/kernel/nt/types/RTL_USER_PROCESS_PARAMETERS.hh>"
         ],


### PR DESCRIPTION
## Summary

This PR adds two largely independent capabilities on top of the existing
Windows VMI model, plus one small core bug fix. Each is a self-contained
commit and the existing Windows (Win10) paths are behaviour-preserving.

### 1. Native Linux guest introspection (x86_64)

A parallel Linux guest model alongside the Windows one, so the `iv*` tools can
introspect Linux guests:

- **profile/** — `LinuxProfile(Impl)`: loads a compact kernel profile (symbols
  + struct offsets) derived from a Volatility3 ISF.
- **kernel/** — guest detection (MSR_LSTAR vs `entry_SYSCALL_64` → KASLR slide,
  `linux_banner` verification, release parse), `LinuxTask`, `LinuxProcessList`
  (walks `init_task.tasks`), `LinuxSyscalls`/`LinuxSyscallsArm64`,
  `current_task()`, and the public `processes()` / `process_page_directory()`
  APIs.
- **event/** — `LinuxEvent(Impl)`, `LinuxSystemCall` (syscall name + the six
  x86_64 argument registers, decoded path strings, typed flag/enum decoding,
  entry→return correlation) and `LinuxEventTaskInformation` (pid/tgid/comm).
- **injection/** — `SystemCallInjector` + `LinuxInject` for the x86_64 Linux
  ABI: implements `allocate`/`guest_free`/`page_in` plus high-level
  mmap/openat/read/write/execve helpers with argv/envp marshaling.
- **wiring** — `DomainImpl::detect_guest()` tries Linux after Windows, gated on
  a configured profile (`INTROVIRT_LINUX_PROFILE`) whose `linux_banner`
  verifies; Linux branches for `ivprocinfo`, `ivguestinfo`, `ivmemwatch`,
  `ivsyscallmon`, `ivreadfile`, `ivwritefile`; and `tools/linux/generate_isf.py`
  to build the profile.

The Linux namespace is `linux_guest` because GCC/Clang predefine the bare
`linux` macro in GNU mode. `src/linux/*.cc` is picked up by the existing
`GLOB_RECURSE` in `src/CMakeLists.txt` — no build-system change required.

### 2. Win11-compatible process launch via NtCreateUserProcess injection

Modern Windows builds (e.g. Win11 22621) launch processes through
`NtCreateUserProcess`, so `ivexec` injects that syscall to start a process
under introspection:

- syscall generator gains opt-in `inject_via_ptr` marshaling for complex
  pointer args (`RTL_USER_PROCESS_PARAMETERS`, `PS_CREATE_INFO`);
- `src/windows/injection/syscall.hh` marshals those complex arguments;
- `ivexec` launches via `NtCreateUserProcess` injection with attach-time
  retries through the KPTI race; new `ivbugcheck` tool.

A follow-up commit fixes the FAST_SYSCALL injection register race that made the
launch unreliable (~50% success, ~35% hard crashes on a fresh-clean guest):

- new `VcpuPauseGuard` (RAII) pauses **only the injected vcpu** for the
  duration of every register access, so `KvmVcpu::registers()` no longer throws
  `EBUSY` → `std::terminate`, and `NtResumeThread` can actually start the
  created process;
- `WindowsEventTaskInformation` snapshots pid/tid/process_name at construction
  so `end_injection` never re-reads the racy shared `kpcr_` (fixes a
  KPTI-stale-pointer SIGSEGV);
- `~RegisterGuard` self-pauses the vcpu around register restore and never
  propagates an exception out of the destructor.

Validated on a real Win11 22621 guest: **crash 0/6** (was ~35%), execution
proven. **Win10 19045 and Linux paths are byte-for-byte unaffected** — the new
pause/catch logic only runs on the path that previously terminated.

### 3. Core fix: guard unarmed `Event::wake()`

`EventImplTpl::wake()` guarded `check_wakeup_` only with `introvirt_assert()`,
which is a no-op in release builds. An unarmed or duplicate wake therefore
invoked an empty `std::function` and threw `std::bad_function_call`, aborting
the event session mid-trace. It now returns `WakeAction::PASS` when no wakeup
is armed; behaviour is unchanged for the armed path.

## Known limitations (honest scope)

- **Linux per-event PID/comm attribution is `0:0` under KPTI.** The syscall
  event fires before `entry_SYSCALL_64`'s CR3 switch, so the live CR3 can't
  read the per-CPU `current_task`. The syscall stream itself (names, decoded
  args/paths) is intact; a physical-memory `current_task` read is the planned
  follow-up.
- **arm64 is only the syscall table** (`LinuxSyscallsArm64`) — a data-only
  first brick, not a working port. IntroVirt is x86-coupled throughout, and a
  real arm64 port is gated on KVMi/KVM-VMI host arm64 introspection support.
- Linux detection is opt-in via `INTROVIRT_LINUX_PROFILE`, so this is inert for
  existing Windows workflows.

## Testing

- Win11 22621 injection validated on a real guest (0/6 crashes, execution
  proven); Win10 19045 unaffected.
- Linux introspection exercised against x86_64 guests via the `iv*` Linux
  branches.